### PR TITLE
Fixing the api generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
     - "2.7"
 install:
-    - pip install pep8 pylint
+    - pip install tox
 script:
-    - pep8 -r --show-source . --exclude ./foreman/definitions.py
+    - tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
-include *rst
+include *.rst
 include LICENSE
 include *.py
+include foreman/definitions/*.json

--- a/foreman/definitions/1.4.2-v1.json
+++ b/foreman/definitions/1.4.2-v1.json
@@ -1,0 +1,7404 @@
+{
+    "docs": {
+        "info": "\n<p>Foreman v1 is currently the default API version.</p>\n",
+        "name": "Foreman",
+        "copyright": "",
+        "doc_url": "/apidoc/v1",
+        "resources": {
+            "template_kinds": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all template kinds.",
+                                "http_method": "GET",
+                                "api_url": "/api/template_kinds"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/template_kinds/index"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/template_kinds",
+                "name": "Template kinds"
+            },
+            "lookup_keys": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all lookup_keys.",
+                                "http_method": "GET",
+                                "api_url": "/api/lookup_keys"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/lookup_keys/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a lookup key.",
+                                "http_method": "GET",
+                                "api_url": "/api/lookup_keys/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/lookup_keys/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a lookup key.",
+                                "http_method": "POST",
+                                "api_url": "/api/lookup_keys"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "lookup_key",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "key",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[key]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppetclass_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "lookup_key[puppetclass_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "default_value",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[default_value]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "path",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[path]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[description]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "lookup_values_count",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "lookup_key[lookup_values_count]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "lookup_key",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/lookup_keys/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a lookup key.",
+                                "http_method": "PUT",
+                                "api_url": "/api/lookup_keys/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "lookup_key",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "key",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[key]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppetclass_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "lookup_key[puppetclass_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "default_value",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[default_value]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "path",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[path]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[description]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "lookup_values_count",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "lookup_key[lookup_values_count]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "lookup_key",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/lookup_keys/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a lookup key.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/lookup_keys/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/lookup_keys/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/lookup_keys",
+                "name": "Lookup keys"
+            },
+            "hostgroups": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all hostgroups.",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hostgroups/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a hostgroup.",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hostgroups/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an hostgroup.",
+                                "http_method": "POST",
+                                "api_url": "/api/hostgroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "hostgroup",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "hostgroup[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "parent_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[parent_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[environment_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[architecture_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[medium_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[ptable_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[subnet_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[domain_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "hostgroup",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hostgroups/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an hostgroup.",
+                                "http_method": "PUT",
+                                "api_url": "/api/hostgroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "hostgroup",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "hostgroup[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "parent_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[parent_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[environment_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[architecture_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[medium_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[ptable_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[subnet_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[domain_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "hostgroup",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hostgroups/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an hostgroup.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hostgroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hostgroups/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/hostgroups",
+                "name": "Hostgroups"
+            },
+            "environments": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "import_puppetclasses",
+                        "apis": [
+                            {
+                                "short_description": "Import puppet classes from puppet proxy.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_proxy_id",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "smart_proxy_id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "environment_id",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "environment_id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "dryrun",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be 'true' or 'false'",
+                                "full_name": "dryrun",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/import_puppetclasses"
+                    },
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all environments.",
+                                "http_method": "GET",
+                                "api_url": "/api/environments"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an environment.",
+                                "http_method": "GET",
+                                "api_url": "/api/environments/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/environments"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "environment",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "environment[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "environment",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an environment.",
+                                "http_method": "PUT",
+                                "api_url": "/api/environments/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "environment",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "environment[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "environment",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an environment.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/environments/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/environments",
+                "name": "Environments"
+            },
+            "ptables": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all ptables.",
+                                "http_method": "GET",
+                                "api_url": "/api/ptables"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/ptables/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a ptable.",
+                                "http_method": "GET",
+                                "api_url": "/api/ptables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/ptables/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a ptable.",
+                                "http_method": "POST",
+                                "api_url": "/api/ptables"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "ptable",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "layout",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[layout]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[os_family]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "ptable",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/ptables/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a ptable.",
+                                "http_method": "PUT",
+                                "api_url": "/api/ptables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "ptable",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "layout",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[layout]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[os_family]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "ptable",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/ptables/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a ptable.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/ptables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/ptables/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/ptables",
+                "name": "Ptables"
+            },
+            "compute_resources": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all compute resources.",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/compute_resources/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an compute resource.",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/compute_resources/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a compute resource.",
+                                "http_method": "POST",
+                                "api_url": "/api/compute_resources"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provider",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[provider]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Providers include</p>\n"
+                                    },
+                                    {
+                                        "name": "url",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[url]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>URL for Libvirt, Ovirt, and Openstack</p>\n"
+                                    },
+                                    {
+                                        "name": "description",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[description]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "user",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[user]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2.</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[password]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2</p>\n"
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[uuid]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>for Ovirt, Vmware Datacenter</p>\n"
+                                    },
+                                    {
+                                        "name": "region",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[region]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>for EC2 only</p>\n"
+                                    },
+                                    {
+                                        "name": "tenant",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[tenant]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>for Openstack only</p>\n"
+                                    },
+                                    {
+                                        "name": "server",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[server]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>for Vmware</p>\n"
+                                    }
+                                ],
+                                "full_name": "compute_resource",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/compute_resources/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a compute resource.",
+                                "http_method": "PUT",
+                                "api_url": "/api/compute_resources/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "compute_resource",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provider",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[provider]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Providers include</p>\n"
+                                    },
+                                    {
+                                        "name": "url",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[url]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>URL for Libvirt, Ovirt, and Openstack</p>\n"
+                                    },
+                                    {
+                                        "name": "description",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[description]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "user",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[user]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2.</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[password]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2</p>\n"
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[uuid]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>for Ovirt, Vmware Datacenter</p>\n"
+                                    },
+                                    {
+                                        "name": "region",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[region]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>for EC2 only</p>\n"
+                                    },
+                                    {
+                                        "name": "tenant",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[tenant]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>for Openstack only</p>\n"
+                                    },
+                                    {
+                                        "name": "server",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[server]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>for Vmware</p>\n"
+                                    }
+                                ],
+                                "full_name": "compute_resource",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/compute_resources/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a compute resource.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/compute_resources/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/compute_resources/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/compute_resources",
+                "name": "Compute resources"
+            },
+            "common_parameters": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all common parameters.",
+                                "http_method": "GET",
+                                "api_url": "/api/common_parameters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/common_parameters/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a common parameter.",
+                                "http_method": "GET",
+                                "api_url": "/api/common_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/common_parameters/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a common_parameter",
+                                "http_method": "POST",
+                                "api_url": "/api/common_parameters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "common_parameter",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "value",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[value]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "common_parameter",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/common_parameters/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a common_parameter",
+                                "http_method": "PUT",
+                                "api_url": "/api/common_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "common_parameter",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "value",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[value]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "common_parameter",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/common_parameters/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a common_parameter",
+                                "http_method": "DELETE",
+                                "api_url": "/api/common_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/common_parameters/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/common_parameters",
+                "name": "Common parameters"
+            },
+            "images": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all images for compute resource",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            },
+                            {
+                                "name": "compute_resource_id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/images/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an image",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "compute_resource_id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/images/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a image",
+                                "http_method": "POST",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource_id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "image",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "username",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[username]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[uuid]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[architecture_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "image",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/images/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a image.",
+                                "http_method": "PUT",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource_id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "image",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "username",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[username]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[uuid]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[architecture_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "image",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/images/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an image.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource_id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/images/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/images",
+                "name": "Images"
+            },
+            "home": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "Show available links.",
+                                "http_method": "GET",
+                                "api_url": "/api"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/home/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "status",
+                        "apis": [
+                            {
+                                "short_description": "Show status.",
+                                "http_method": "GET",
+                                "api_url": "/api/status"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/home/status"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/home",
+                "name": "Home"
+            },
+            "audits": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all audits.",
+                                "http_method": "GET",
+                                "api_url": "/api/audits"
+                            },
+                            {
+                                "short_description": "List all audits for a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/audits"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/audits/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an audit",
+                                "http_method": "GET",
+                                "api_url": "/api/audits/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/audits/show"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/audits",
+                "name": "Audits"
+            },
+            "bookmarks": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all bookmarks.",
+                                "http_method": "GET",
+                                "api_url": "/api/bookmarks"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/bookmarks/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a bookmark.",
+                                "http_method": "GET",
+                                "api_url": "/api/bookmarks/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/bookmarks/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a bookmark.",
+                                "http_method": "POST",
+                                "api_url": "/api/bookmarks"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "bookmark",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "controller",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[controller]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "query",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[query]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "public",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "bookmark[public]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "bookmark",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/bookmarks/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a bookmark.",
+                                "http_method": "PUT",
+                                "api_url": "/api/bookmarks/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "bookmark",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "controller",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[controller]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "query",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[query]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "public",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "bookmark[public]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "bookmark",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/bookmarks/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a bookmark.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/bookmarks/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/bookmarks/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/bookmarks",
+                "name": "Bookmarks"
+            },
+            "auth_source_ldaps": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all authsource ldaps",
+                                "http_method": "GET",
+                                "api_url": "/api/auth_source_ldaps"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/auth_source_ldaps/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an authsource ldap.",
+                                "http_method": "GET",
+                                "api_url": "/api/auth_source_ldaps/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/auth_source_ldaps/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an auth_source_ldap.",
+                                "http_method": "POST",
+                                "api_url": "/api/auth_source_ldaps"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "auth_source_ldap",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[host]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "port",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "auth_source_ldap[port]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>defaults to 389</p>\n"
+                                    },
+                                    {
+                                        "name": "account",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "base_dn",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[base_dn]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "account_password",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account_password]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_login",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_login]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_firstname",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_firstname]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_lastname",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_lastname]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_mail",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_mail]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "onthefly_register",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[onthefly_register]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "tls",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[tls]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "auth_source_ldap",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/auth_source_ldaps/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an auth_source_ldap.",
+                                "http_method": "PUT",
+                                "api_url": "/api/auth_source_ldaps/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "auth_source_ldap",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[host]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "port",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "auth_source_ldap[port]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>defaults to 389</p>\n"
+                                    },
+                                    {
+                                        "name": "account",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "base_dn",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[base_dn]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "account_password",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account_password]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_login",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_login]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_firstname",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_firstname]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_lastname",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_lastname]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_mail",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_mail]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "onthefly_register",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[onthefly_register]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "tls",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[tls]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "auth_source_ldap",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/auth_source_ldaps/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an auth_source_ldap.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/auth_source_ldaps/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/auth_source_ldaps/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/auth_source_ldaps",
+                "name": "Auth source ldaps"
+            },
+            "statistics": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "Get statistics",
+                                "http_method": "GET",
+                                "api_url": "/api/statistics"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/statistics/index"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/statistics",
+                "name": "Statistics"
+            },
+            "media": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all media.",
+                                "http_method": "GET",
+                                "api_url": "/api/media"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>for example, name ASC, or name DESC</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/media/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a medium.",
+                                "http_method": "GET",
+                                "api_url": "/api/media/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/media/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a medium.",
+                                "http_method": "POST",
+                                "api_url": "/api/media"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "medium",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[name]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Name of media</p>\n"
+                                    },
+                                    {
+                                        "name": "path",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[path]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>The path to the medium, can be a URL or a valid NFS server (exclusive of\nthe architecture).</p>\n\n<p>for example <a\nhref=\"http://mirror.centos.org/centos/$version/os/$arch\">mirror.centos.org/centos/$version/os/$arch</a>\nwhere $arch will be substituted for the host's actual OS architecture and\n$version, $major and $minor will be substituted for the version of the\noperating system.</p>\n\n<p>Solaris and Debian media may also use $release.</p>\n"
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[os_family]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>The family that the operating system belongs to.</p>\n\n<p>Available families:</p>\n<ul><li>\n<p>AIX</p>\n</li><li>\n<p>Archlinux</p>\n</li><li>\n<p>Debian</p>\n</li><li>\n<p>Freebsd</p>\n</li><li>\n<p>Gentoo</p>\n</li><li>\n<p>Junos</p>\n</li><li>\n<p>Redhat</p>\n</li><li>\n<p>Solaris</p>\n</li><li>\n<p>Suse</p>\n</li><li>\n<p>Windows</p>\n</li></ul>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "medium[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "medium",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/media/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a medium.",
+                                "http_method": "PUT",
+                                "api_url": "/api/media/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "medium",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[name]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Name of media</p>\n"
+                                    },
+                                    {
+                                        "name": "path",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[path]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>The path to the medium, can be a URL or a valid NFS server (exclusive of\nthe architecture).</p>\n\n<p>for example <a\nhref=\"http://mirror.centos.org/centos/$version/os/$arch\">mirror.centos.org/centos/$version/os/$arch</a>\nwhere $arch will be substituted for the host's actual OS architecture and\n$version, $major and $minor will be substituted for the version of the\noperating system.</p>\n\n<p>Solaris and Debian media may also use $release.</p>\n"
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[os_family]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>The family that the operating system belongs to.</p>\n\n<p>Available families:</p>\n<ul><li>\n<p>AIX</p>\n</li><li>\n<p>Archlinux</p>\n</li><li>\n<p>Debian</p>\n</li><li>\n<p>Freebsd</p>\n</li><li>\n<p>Gentoo</p>\n</li><li>\n<p>Junos</p>\n</li><li>\n<p>Redhat</p>\n</li><li>\n<p>Solaris</p>\n</li><li>\n<p>Suse</p>\n</li><li>\n<p>Windows</p>\n</li></ul>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "medium[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "medium",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/media/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a medium.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/media/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/media/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/media",
+                "name": "Media"
+            },
+            "autosign": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all autosign",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_proxies/smart_proxy_id/autosign"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/autosign/index"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/autosign",
+                "name": "Autosign"
+            },
+            "fact_values": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all fact values.",
+                                "http_method": "GET",
+                                "api_url": "/api/fact_values"
+                            },
+                            {
+                                "short_description": "List all fact values of a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/facts"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/fact_values/index"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/fact_values",
+                "name": "Fact values"
+            },
+            "subnets": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List of subnets",
+                                "http_method": "GET",
+                                "api_url": "/api/subnets"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/subnets/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a subnet.",
+                                "http_method": "GET",
+                                "api_url": "/api/subnets/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/subnets/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a subnet",
+                                "http_method": "POST",
+                                "api_url": "/api/subnets"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "subnet",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[name]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Subnet name</p>\n"
+                                    },
+                                    {
+                                        "name": "network",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[network]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Subnet network</p>\n"
+                                    },
+                                    {
+                                        "name": "mask",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[mask]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Netmask for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "gateway",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[gateway]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_primary",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_primary]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_secondary",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_secondary]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Secondary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "from",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[from]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Starting IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "to",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[to]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Ending IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "vlanid",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[vlanid]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>VLAN ID for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_ids",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "subnet[domain_ids]",
+                                        "expected_type": "array",
+                                        "description": "\n<p>Domains in which this subnet is part</p>\n"
+                                    },
+                                    {
+                                        "name": "dhcp_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dhcp_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>DHCP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "tftp_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[tftp_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>TFTP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dns_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>DNS Proxy to use within this subnet</p>\n"
+                                    }
+                                ],
+                                "full_name": "subnet",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/subnets/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a subnet",
+                                "http_method": "PUT",
+                                "api_url": "/api/subnets/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a number.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": "\n<p>Subnet numeric identifier</p>\n"
+                            },
+                            {
+                                "name": "subnet",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[name]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Subnet name</p>\n"
+                                    },
+                                    {
+                                        "name": "network",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[network]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Subnet network</p>\n"
+                                    },
+                                    {
+                                        "name": "mask",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[mask]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Netmask for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "gateway",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[gateway]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_primary",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_primary]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_secondary",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_secondary]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Secondary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "from",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[from]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Starting IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "to",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[to]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Ending IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "vlanid",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[vlanid]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>VLAN ID for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_ids",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "subnet[domain_ids]",
+                                        "expected_type": "array",
+                                        "description": "\n<p>Domains in which this subnet is part</p>\n"
+                                    },
+                                    {
+                                        "name": "dhcp_id",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dhcp_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>DHCP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "tftp_id",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[tftp_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>TFTP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dns_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>DNS Proxy to use within this subnet</p>\n"
+                                    }
+                                ],
+                                "full_name": "subnet",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/subnets/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a subnet",
+                                "http_method": "DELETE",
+                                "api_url": "/api/subnets/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a number.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": "\n<p>Subnet numeric identifier</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/subnets/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/subnets",
+                "name": "Subnets"
+            },
+            "users": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all users.",
+                                "http_method": "GET",
+                                "api_url": "/api/users"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/users/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an user.",
+                                "http_method": "GET",
+                                "api_url": "/api/users/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/users/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an user.",
+                                "http_method": "POST",
+                                "api_url": "/api/users"
+                            }
+                        ],
+                        "full_description": "\n<p>Adds role 'Anonymous' to the user by default</p>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "user",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "login",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[login]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "firstname",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[firstname]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "lastname",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[lastname]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "mail",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[mail]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "admin",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "user[admin]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Is an admin account?</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[password]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "auth_source_id",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be Integer",
+                                        "full_name": "user[auth_source_id]",
+                                        "expected_type": "numeric",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "user",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/users/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an user.",
+                                "http_method": "PUT",
+                                "api_url": "/api/users/:id"
+                            }
+                        ],
+                        "full_description": "\n<p>Adds role 'Anonymous' to the user if it is not already present. Only admin\ncan set admin account.</p>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "user",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "login",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[login]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "firstname",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "user[firstname]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "lastname",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "user[lastname]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "mail",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[mail]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "admin",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "user[admin]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Is an admin account?</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[password]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "user",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/users/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an user.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/users/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/users/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/users",
+                "name": "Users"
+            },
+            "models": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all models.",
+                                "http_method": "GET",
+                                "api_url": "/api/models"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/models/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a model.",
+                                "http_method": "GET",
+                                "api_url": "/api/models/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/models/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a model.",
+                                "http_method": "POST",
+                                "api_url": "/api/models"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "model",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "info",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[info]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "vendor_class",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[vendor_class]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hardware_model",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[hardware_model]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "model",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/models/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a model.",
+                                "http_method": "PUT",
+                                "api_url": "/api/models/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "model",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "info",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[info]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "vendor_class",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[vendor_class]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hardware_model",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[hardware_model]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "model",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/models/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a model.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/models/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/models/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/models",
+                "name": "Models"
+            },
+            "config_templates": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List templates",
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show template details",
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a template",
+                                "http_method": "POST",
+                                "api_url": "/api/config_templates"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "config_template",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[name]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>template name</p>\n"
+                                    },
+                                    {
+                                        "name": "template",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[template]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "snippet",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "config_template[snippet]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "audit_comment",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[audit_comment]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "template_kind_id",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "config_template[template_kind_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>not relevant for snippet</p>\n"
+                                    },
+                                    {
+                                        "name": "template_combinations_attributes",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[template_combinations_attributes]",
+                                        "expected_type": "array",
+                                        "description": "\n<p>Array of template combinations (hostgroup_id, environment_id)</p>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "description": "\n<p>Array of operating systems ID to associate the template with</p>\n"
+                                    }
+                                ],
+                                "full_name": "config_template",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a template",
+                                "http_method": "PUT",
+                                "api_url": "/api/config_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "config_template",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[name]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>template name</p>\n"
+                                    },
+                                    {
+                                        "name": "template",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[template]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "snippet",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "config_template[snippet]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "audit_comment",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[audit_comment]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "template_kind_id",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "config_template[template_kind_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>not relevant for snippet</p>\n"
+                                    },
+                                    {
+                                        "name": "template_combinations_attributes",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[template_combinations_attributes]",
+                                        "expected_type": "array",
+                                        "description": "\n<p>Array of template combinations (hostgroup_id, environment_id)</p>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "description": "\n<p>Array of operating systems ID to associate the template with</p>\n"
+                                    }
+                                ],
+                                "full_name": "config_template",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "revision",
+                        "apis": [
+                            {
+                                "short_description": null,
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates/revision"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "version",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "version",
+                                "expected_type": "string",
+                                "description": "\n<p>template version</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/revision"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a template",
+                                "http_method": "DELETE",
+                                "api_url": "/api/config_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/destroy"
+                    },
+                    {
+                        "errors": [],
+                        "name": "build_pxe_default",
+                        "apis": [
+                            {
+                                "short_description": "Change the default PXE menu on all configured TFTP servers",
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates/build_pxe_default"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/build_pxe_default"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/config_templates",
+                "name": "Config templates"
+            },
+            "usergroups": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all usergroups.",
+                                "http_method": "GET",
+                                "api_url": "/api/usergroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            },
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/usergroups/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a usergroup.",
+                                "http_method": "GET",
+                                "api_url": "/api/usergroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/usergroups/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a usergroup.",
+                                "http_method": "POST",
+                                "api_url": "/api/usergroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "usergroup",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "usergroup[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "usergroup",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/usergroups/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a usergroup.",
+                                "http_method": "PUT",
+                                "api_url": "/api/usergroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "usergroup",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "usergroup[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "usergroup",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/usergroups/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a usergroup.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/usergroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/usergroups/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/usergroups",
+                "name": "Usergroups"
+            },
+            "operatingsystems": {
+                "api_url": "/api",
+                "full_description": "",
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all operating systems.",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>for example, name ASC, or name DESC</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an OS.",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an OS.",
+                                "http_method": "POST",
+                                "api_url": "/api/operatingsystems"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "operatingsystem",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must match regular expression /\\A(\\S+)\\Z/.",
+                                        "full_name": "operatingsystem[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "major",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[major]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "minor",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[minor]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[description]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "family",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[family]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "release_name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[release_name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "operatingsystem",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an OS.",
+                                "http_method": "PUT",
+                                "api_url": "/api/operatingsystems/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "operatingsystem",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must match regular expression /\\A(\\S+)\\Z/.",
+                                        "full_name": "operatingsystem[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "major",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[major]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "minor",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[minor]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[description]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "family",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[family]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "release_name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[release_name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "operatingsystem",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an OS.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/operatingsystems/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/destroy"
+                    },
+                    {
+                        "errors": [],
+                        "name": "bootfiles",
+                        "apis": [
+                            {
+                                "short_description": "List boot files an OS.",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems/:id/bootfiles"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "medium",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "medium",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "architecture",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "architecture",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/bootfiles"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/operatingsystems",
+                "name": "Operating systems"
+            },
+            "puppetclasses": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all puppetclasses.",
+                                "http_method": "GET",
+                                "api_url": "/api/puppetclasses"
+                            },
+                            {
+                                "short_description": "List all puppetclasses of a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/puppetclasses/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a puppetclass.",
+                                "http_method": "GET",
+                                "api_url": "/api/puppetclasses/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/puppetclasses/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a puppetclass.",
+                                "http_method": "POST",
+                                "api_url": "/api/puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "puppetclass",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "puppetclass[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "puppetclass",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/puppetclasses/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a puppetclass.",
+                                "http_method": "PUT",
+                                "api_url": "/api/puppetclasses/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "puppetclass",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "puppetclass[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "puppetclass",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/puppetclasses/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a puppetclass.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/puppetclasses/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/puppetclasses/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/puppetclasses",
+                "name": "Puppetclasses"
+            },
+            "roles": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all roles.",
+                                "http_method": "GET",
+                                "api_url": "/api/roles"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/roles/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an role.",
+                                "http_method": "GET",
+                                "api_url": "/api/roles/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/roles/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an role.",
+                                "http_method": "POST",
+                                "api_url": "/api/roles"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "role",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "role[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "role",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/roles/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an role.",
+                                "http_method": "PUT",
+                                "api_url": "/api/roles/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "role",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "role[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "role",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/roles/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an role.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/roles/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/roles/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/roles",
+                "name": "Roles"
+            },
+            "settings": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all settings.",
+                                "http_method": "GET",
+                                "api_url": "/api/settings"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/settings/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an setting.",
+                                "http_method": "GET",
+                                "api_url": "/api/settings/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/settings/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a setting.",
+                                "http_method": "PUT",
+                                "api_url": "/api/settings/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "setting",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "value",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "setting[value]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "setting",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/settings/update"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/settings",
+                "name": "Settings"
+            },
+            "smart_proxies": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "import_puppetclasses",
+                        "apis": [
+                            {
+                                "short_description": "Import puppet classes from puppet proxy.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_proxy_id",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "smart_proxy_id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "environment_id",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "environment_id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "dryrun",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be 'true' or 'false'",
+                                "full_name": "dryrun",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/import_puppetclasses"
+                    },
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all smart_proxies.",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_proxies"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "type",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "type",
+                                "expected_type": "string",
+                                "description": "\n<p>filter by type</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a smart proxy.",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_proxies/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a smart proxy.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "smart_proxy",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "url",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[url]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "smart_proxy",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a smart proxy.",
+                                "http_method": "PUT",
+                                "api_url": "/api/smart_proxies/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_proxy",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "url",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[url]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "smart_proxy",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a smart_proxy.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/smart_proxies/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/destroy"
+                    },
+                    {
+                        "errors": [],
+                        "name": "refresh",
+                        "apis": [
+                            {
+                                "short_description": "Refresh smart proxy features",
+                                "http_method": "PUT",
+                                "api_url": "/api/smart_proxies/:id/refresh"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/refresh"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/smart_proxies",
+                "name": "Smart proxies"
+            },
+            "reports": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all reports.",
+                                "http_method": "GET",
+                                "api_url": "/api/reports"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/reports/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a report.",
+                                "http_method": "GET",
+                                "api_url": "/api/reports/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/reports/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a report.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/reports/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/reports/destroy"
+                    },
+                    {
+                        "errors": [],
+                        "name": "last",
+                        "apis": [
+                            {
+                                "short_description": "Show the last report for a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/reports/last"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/reports/last"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/reports",
+                "name": "Reports"
+            },
+            "hosts": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all hosts.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a host.",
+                                "http_method": "POST",
+                                "api_url": "/api/hosts"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[environment_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ip",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[ip]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>not required if using a subnet with dhcp proxy</p>\n"
+                                    },
+                                    {
+                                        "name": "mac",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[mac]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>not required if its a virtual machine</p>\n"
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[architecture_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[domain_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_class_ids",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[puppet_class_ids]",
+                                        "expected_type": "array",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[medium_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[ptable_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[subnet_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "sp_subnet_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[sp_subnet_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "model_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[model_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hostgroup_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[hostgroup_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "owner_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[owner_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "image_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[image_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host_parameters_attributes",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[host_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "build",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[build]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "enabled",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[enabled]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provision_method",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[provision_method]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "managed",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[managed]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "progress_report_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[progress_report_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>UUID to track orchestration tasks status, GET\n/api/orchestration/:UUID/tasks</p>\n"
+                                    },
+                                    {
+                                        "name": "capabilities",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[capabilities]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_attributes",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a Hash",
+                                        "params": [],
+                                        "full_name": "host[compute_attributes]",
+                                        "expected_type": "hash",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "host",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a host.",
+                                "http_method": "PUT",
+                                "api_url": "/api/hosts/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "host",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[environment_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ip",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[ip]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>not required if using a subnet with dhcp proxy</p>\n"
+                                    },
+                                    {
+                                        "name": "mac",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[mac]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>not required if its a virtual machine</p>\n"
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[architecture_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[domain_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_class_ids",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[puppet_class_ids]",
+                                        "expected_type": "array",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[medium_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[ptable_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[subnet_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "sp_subnet_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[sp_subnet_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "model_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[model_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hostgroup_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[hostgroup_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "owner_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[owner_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "image_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[image_id]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host_parameters_attributes",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[host_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "build",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[build]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "enabled",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[enabled]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provision_method",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[provision_method]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "managed",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[managed]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "progress_report_id",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[progress_report_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>UUID to track orchestration tasks status, GET\n/api/orchestration/:UUID/tasks</p>\n"
+                                    },
+                                    {
+                                        "name": "capabilities",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[capabilities]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_attributes",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a Hash",
+                                        "params": [],
+                                        "full_name": "host[compute_attributes]",
+                                        "expected_type": "hash",
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "host",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an host.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hosts/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/destroy"
+                    },
+                    {
+                        "errors": [],
+                        "name": "status",
+                        "apis": [
+                            {
+                                "short_description": "Get status of host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:id/status"
+                            }
+                        ],
+                        "full_description": "\n<p>Return value may either be one of the following:</p>\n<ul><li>\n<p>missing</p>\n</li><li>\n<p>failed</p>\n</li><li>\n<p>pending</p>\n</li><li>\n<p>changed</p>\n</li><li>\n<p>unchanged</p>\n</li><li>\n<p>unreported</p>\n</li></ul>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/status"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/hosts",
+                "name": "Hosts"
+            },
+            "dashboard": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "Get Dashboard results",
+                                "http_method": "GET",
+                                "api_url": "/api/dashboard"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/dashboard/index"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/dashboard",
+                "name": "Dashboard"
+            },
+            "domains": {
+                "api_url": "/api",
+                "full_description": "\n<p>Foreman considers a domain and a DNS zone as the same thing. That is, if\nyou are planning to manage a site where all the machines are or the form\n<em>hostname</em>.<strong>somewhere.com</strong> then the domain is\n<strong>somewhere.com</strong>. This allows Foreman to associate a puppet\nvariable with a domain/site and automatically append this variable to all\nexternal node requests made by machines at that site.</p>\n",
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List of domains",
+                                "http_method": "GET",
+                                "api_url": "/api/domains"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/domains/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a domain.",
+                                "http_method": "GET",
+                                "api_url": "/api/domains/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": "\n<p>May be numerical id or domain name</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/domains/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a domain.",
+                                "http_method": "POST",
+                                "api_url": "/api/domains"
+                            }
+                        ],
+                        "full_description": "\n<p>The <strong>fullname</strong> field is used for human readability in\nreports and other pages that refer to domains, and also available as an\nexternal node parameter</p>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "domain",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[name]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>The full DNS Domain name</p>\n"
+                                    },
+                                    {
+                                        "name": "fullname",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[fullname]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Full name describing the domain</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "domain[dns_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>DNS Proxy to use within this domain</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_parameters_attributes",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "domain[domain_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "description": "\n<p>Array of parameters (name, value)</p>\n"
+                                    }
+                                ],
+                                "full_name": "domain",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/domains/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a domain.",
+                                "http_method": "PUT",
+                                "api_url": "/api/domains/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "domain",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[name]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>The full DNS Domain name</p>\n"
+                                    },
+                                    {
+                                        "name": "fullname",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[fullname]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>Full name describing the domain</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "domain[dns_id]",
+                                        "expected_type": "string",
+                                        "description": "\n<p>DNS Proxy to use within this domain</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_parameters_attributes",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "domain[domain_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "description": "\n<p>Array of parameters (name, value)</p>\n"
+                                    }
+                                ],
+                                "full_name": "domain",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/domains/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a domain.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/domains/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/domains/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/domains",
+                "name": "Domains"
+            },
+            "architectures": {
+                "api_url": "/api",
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all architectures.",
+                                "http_method": "GET",
+                                "api_url": "/api/architectures"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/architectures/index"
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an architecture.",
+                                "http_method": "GET",
+                                "api_url": "/api/architectures/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/architectures/show"
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an architecture.",
+                                "http_method": "POST",
+                                "api_url": "/api/architectures"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "architecture",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "architecture[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "architecture[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "description": "\n<p>Operatingsystem ID's</p>\n"
+                                    }
+                                ],
+                                "full_name": "architecture",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/architectures/create"
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an architecture.",
+                                "http_method": "PUT",
+                                "api_url": "/api/architectures/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            },
+                            {
+                                "name": "architecture",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "architecture[name]",
+                                        "expected_type": "string",
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "architecture[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "description": "\n<p>Operatingsystem ID's</p>\n"
+                                    }
+                                ],
+                                "full_name": "architecture",
+                                "expected_type": "hash",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/architectures/update"
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an architecture.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/architectures/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/architectures/destroy"
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/architectures",
+                "name": "Architectures"
+            }
+        },
+        "api_url": "/api"
+    }
+}

--- a/foreman/definitions/1.4.2-v2.json
+++ b/foreman/definitions/1.4.2-v2.json
@@ -1,0 +1,10408 @@
+{
+    "docs": {
+        "api_url": "/api",
+        "copyright": "",
+        "doc_url": "/apidoc/v2",
+        "info": "\n<p>Foreman v2 is currently in development and is not the default version. You\nmay use v2 by either passing 'version=2' in the Accept Header or entering\napi/v2/ in the URL.</p>\n",
+        "name": "Foreman",
+        "resources": {
+            "architectures": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/architectures",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/architectures",
+                                "http_method": "GET",
+                                "short_description": "List all architectures."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/architectures/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/architectures/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an architecture."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/architectures/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/architectures",
+                                "http_method": "POST",
+                                "short_description": "Create an architecture."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/architectures/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "architecture",
+                                "name": "architecture",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "architecture[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Operatingsystem ID's</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "architecture[operatingsystem_ids]",
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/architectures/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update an architecture."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/architectures/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "architecture",
+                                "name": "architecture",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "architecture[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Operatingsystem ID's</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "architecture[operatingsystem_ids]",
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/architectures/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an architecture."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/architectures/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Architectures",
+                "short_description": null,
+                "version": "v2"
+            },
+            "audits": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/audits",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/audits",
+                                "http_method": "GET",
+                                "short_description": "List all audits."
+                            },
+                            {
+                                "api_url": "/api/hosts/:host_id/audits",
+                                "http_method": "GET",
+                                "short_description": "List all audits for a given host."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/audits/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/audits/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an audit"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/audits/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Audits",
+                "short_description": null,
+                "version": "v2"
+            },
+            "auth_source_ldaps": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/auth_source_ldaps",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/auth_source_ldaps",
+                                "http_method": "GET",
+                                "short_description": "List all authsource ldaps"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/auth_source_ldaps/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/auth_source_ldaps/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an authsource ldap."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/auth_source_ldaps/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/auth_source_ldaps",
+                                "http_method": "POST",
+                                "short_description": "Create an auth_source_ldap."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/auth_source_ldaps/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "auth_source_ldap",
+                                "name": "auth_source_ldap",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[host]",
+                                        "name": "host",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>defaults to 389</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[port]",
+                                        "name": "port",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[account]",
+                                        "name": "account",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[base_dn]",
+                                        "name": "base_dn",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[account_password]",
+                                        "name": "account_password",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[attr_login]",
+                                        "name": "attr_login",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[attr_firstname]",
+                                        "name": "attr_firstname",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[attr_lastname]",
+                                        "name": "attr_lastname",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[attr_mail]",
+                                        "name": "attr_mail",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[onthefly_register]",
+                                        "name": "onthefly_register",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[tls]",
+                                        "name": "tls",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/auth_source_ldaps/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update an auth_source_ldap."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/auth_source_ldaps/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "auth_source_ldap",
+                                "name": "auth_source_ldap",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[host]",
+                                        "name": "host",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>defaults to 389</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[port]",
+                                        "name": "port",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[account]",
+                                        "name": "account",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[base_dn]",
+                                        "name": "base_dn",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[account_password]",
+                                        "name": "account_password",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[attr_login]",
+                                        "name": "attr_login",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[attr_firstname]",
+                                        "name": "attr_firstname",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[attr_lastname]",
+                                        "name": "attr_lastname",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[attr_mail]",
+                                        "name": "attr_mail",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[onthefly_register]",
+                                        "name": "onthefly_register",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "auth_source_ldap[tls]",
+                                        "name": "tls",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/auth_source_ldaps/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an auth_source_ldap."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/auth_source_ldaps/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Auth source ldaps",
+                "short_description": null,
+                "version": "v2"
+            },
+            "autosign": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/autosign",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_proxies/smart_proxy_id/autosign",
+                                "http_method": "GET",
+                                "short_description": "List all autosign"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/autosign/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [],
+                        "see": []
+                    }
+                ],
+                "name": "Autosign",
+                "short_description": null,
+                "version": "v2"
+            },
+            "bookmarks": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/bookmarks",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/bookmarks",
+                                "http_method": "GET",
+                                "short_description": "List all bookmarks."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/bookmarks/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/bookmarks/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a bookmark."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/bookmarks/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/bookmarks",
+                                "http_method": "POST",
+                                "short_description": "Create a bookmark."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/bookmarks/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "bookmark",
+                                "name": "bookmark",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "bookmark[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "bookmark[controller]",
+                                        "name": "controller",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "bookmark[query]",
+                                        "name": "query",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "bookmark[public]",
+                                        "name": "public",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/bookmarks/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a bookmark."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/bookmarks/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "bookmark",
+                                "name": "bookmark",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "bookmark[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "bookmark[controller]",
+                                        "name": "controller",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "bookmark[query]",
+                                        "name": "query",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "bookmark[public]",
+                                        "name": "public",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/bookmarks/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a bookmark."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/bookmarks/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Bookmarks",
+                "short_description": null,
+                "version": "v2"
+            },
+            "common_parameters": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/common_parameters",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/common_parameters",
+                                "http_method": "GET",
+                                "short_description": "List all common parameters."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/common_parameters/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/common_parameters/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a common parameter."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/common_parameters/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/common_parameters",
+                                "http_method": "POST",
+                                "short_description": "Create a common_parameter"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/common_parameters/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "common_parameter",
+                                "name": "common_parameter",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "common_parameter[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "common_parameter[value]",
+                                        "name": "value",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/common_parameters/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a common_parameter"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/common_parameters/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "common_parameter",
+                                "name": "common_parameter",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "common_parameter[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "common_parameter[value]",
+                                        "name": "value",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/common_parameters/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a common_parameter"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/common_parameters/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Common parameters",
+                "short_description": null,
+                "version": "v2"
+            },
+            "compute_resources": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/compute_resources",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources",
+                                "http_method": "GET",
+                                "short_description": "List all compute resources."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/compute_resources/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an compute resource."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/compute_resources/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources",
+                                "http_method": "POST",
+                                "short_description": "Create a compute resource."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/compute_resources/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "compute_resource",
+                                "name": "compute_resource",
+                                "params": [
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Providers include</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[provider]",
+                                        "name": "provider",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>URL for Libvirt, Ovirt, and Openstack</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[url]",
+                                        "name": "url",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[description]",
+                                        "name": "description",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2.</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[user]",
+                                        "name": "user",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[password]",
+                                        "name": "password",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>for Ovirt, Vmware Datacenter</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[uuid]",
+                                        "name": "uuid",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>for EC2 only</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[region]",
+                                        "name": "region",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>for Openstack only</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[tenant]",
+                                        "name": "tenant",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>for Vmware</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[server]",
+                                        "name": "server",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a compute resource."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/compute_resources/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "compute_resource",
+                                "name": "compute_resource",
+                                "params": [
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Providers include</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[provider]",
+                                        "name": "provider",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>URL for Libvirt, Ovirt, and Openstack</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[url]",
+                                        "name": "url",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[description]",
+                                        "name": "description",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2.</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[user]",
+                                        "name": "user",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[password]",
+                                        "name": "password",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>for Ovirt, Vmware Datacenter</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[uuid]",
+                                        "name": "uuid",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>for EC2 only</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[region]",
+                                        "name": "region",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>for Openstack only</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[tenant]",
+                                        "name": "tenant",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>for Vmware</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "compute_resource[server]",
+                                        "name": "server",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a compute resource."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/compute_resources/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources/:id/available_images",
+                                "http_method": "GET",
+                                "short_description": "List available images for a compute resource."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/compute_resources/available_images",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "available_images",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Compute resources",
+                "short_description": null,
+                "version": "v2"
+            },
+            "config_templates": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/config_templates",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/config_templates",
+                                "http_method": "GET",
+                                "short_description": "List templates"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/config_templates/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/config_templates/:id",
+                                "http_method": "GET",
+                                "short_description": "Show template details"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/config_templates/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/config_templates",
+                                "http_method": "POST",
+                                "short_description": "Create a template"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/config_templates/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "config_template",
+                                "name": "config_template",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>template name</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "config_template[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "config_template[template]",
+                                        "name": "template",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "config_template[snippet]",
+                                        "name": "snippet",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "config_template[audit_comment]",
+                                        "name": "audit_comment",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>not relevant for snippet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "config_template[template_kind_id]",
+                                        "name": "template_kind_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Array of template combinations (hostgroup_id, environment_id)</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "config_template[template_combinations_attributes]",
+                                        "name": "template_combinations_attributes",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Array of operating systems ID to associate the template with</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "config_template[operatingsystem_ids]",
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/config_templates/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a template"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/config_templates/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "config_template",
+                                "name": "config_template",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>template name</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "config_template[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "config_template[template]",
+                                        "name": "template",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "config_template[snippet]",
+                                        "name": "snippet",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "config_template[audit_comment]",
+                                        "name": "audit_comment",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>not relevant for snippet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "config_template[template_kind_id]",
+                                        "name": "template_kind_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Array of template combinations (hostgroup_id, environment_id)</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "config_template[template_combinations_attributes]",
+                                        "name": "template_combinations_attributes",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Array of operating systems ID to associate the template with</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "config_template[operatingsystem_ids]",
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/config_templates/revision",
+                                "http_method": "GET",
+                                "short_description": null
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/config_templates/revision",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "revision",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>template version</p>\n",
+                                "expected_type": "string",
+                                "full_name": "version",
+                                "name": "version",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/config_templates/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a template"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/config_templates/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/config_templates/build_pxe_default",
+                                "http_method": "GET",
+                                "short_description": "Change the default PXE menu on all configured TFTP servers"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/config_templates/build_pxe_default",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "build_pxe_default",
+                        "params": [],
+                        "see": []
+                    }
+                ],
+                "name": "Config templates",
+                "short_description": null,
+                "version": "v2"
+            },
+            "dashboard": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/dashboard",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/dashboard",
+                                "http_method": "GET",
+                                "short_description": "Get Dashboard results"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/dashboard/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Dashboard",
+                "short_description": null,
+                "version": "v2"
+            },
+            "domains": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/domains",
+                "formats": null,
+                "full_description": "\n<p>Foreman considers a domain and a DNS zone as the same thing. That is, if\nyou are planning to manage a site where all the machines are or the form\n<em>hostname</em>.<strong>somewhere.com</strong> then the domain is\n<strong>somewhere.com</strong>. This allows Foreman to associate a puppet\nvariable with a domain/site and automatically append this variable to all\nexternal node requests made by machines at that site.</p>\n",
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/domains",
+                                "http_method": "GET",
+                                "short_description": "List of domains"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/domains/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/domains/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a domain."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/domains/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>May be numerical id or domain name</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/domains",
+                                "http_method": "POST",
+                                "short_description": "Create a domain."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/domains/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "\n<p>The <strong>fullname</strong> field is used for human readability in\nreports and other pages that refer to domains, and also available as an\nexternal node parameter</p>\n",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "domain",
+                                "name": "domain",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>The full DNS Domain name</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "domain[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Full name describing the domain</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "domain[fullname]",
+                                        "name": "fullname",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>DNS Proxy to use within this domain</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "domain[dns_id]",
+                                        "name": "dns_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Array of parameters (name, value)</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "domain[domain_parameters_attributes]",
+                                        "name": "domain_parameters_attributes",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/domains/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a domain."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/domains/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "domain",
+                                "name": "domain",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>The full DNS Domain name</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "domain[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Full name describing the domain</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "domain[fullname]",
+                                        "name": "fullname",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>DNS Proxy to use within this domain</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "domain[dns_id]",
+                                        "name": "dns_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Array of parameters (name, value)</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "domain[domain_parameters_attributes]",
+                                        "name": "domain_parameters_attributes",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/domains/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a domain."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/domains/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Domains",
+                "short_description": null,
+                "version": "v2"
+            },
+            "environments": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/environments",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_proxies/:id/import_puppetclasses",
+                                "http_method": "POST",
+                                "short_description": "Import puppet classes from puppet proxy."
+                            },
+                            {
+                                "api_url": "/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses",
+                                "http_method": "POST",
+                                "short_description": "Import puppet classes from puppet proxy for particular environment."
+                            },
+                            {
+                                "api_url": "/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses",
+                                "http_method": "POST",
+                                "short_description": "Import puppet classes from puppet proxy for particular environment."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/environments/import_puppetclasses",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "import_puppetclasses",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "smart_proxy_id",
+                                "name": "smart_proxy_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "environment_id",
+                                "name": "environment_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "dryrun",
+                                "name": "dryrun",
+                                "required": false,
+                                "validator": "Must be 'true' or 'false'"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/environments",
+                                "http_method": "GET",
+                                "short_description": "List all environments."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/environments/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/environments/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an environment."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/environments/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/environments",
+                                "http_method": "POST",
+                                "short_description": "Create an environment."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/environments/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "environment",
+                                "name": "environment",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "environment[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/environments/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update an environment."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/environments/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "environment",
+                                "name": "environment",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "environment[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/environments/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an environment."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/environments/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Environments",
+                "short_description": null,
+                "version": "v2"
+            },
+            "fact_values": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/fact_values",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/fact_values",
+                                "http_method": "GET",
+                                "short_description": "List all fact values."
+                            },
+                            {
+                                "api_url": "/api/hosts/:host_id/facts",
+                                "http_method": "GET",
+                                "short_description": "List all fact values of a given host."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/fact_values/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Fact values",
+                "short_description": null,
+                "version": "v2"
+            },
+            "home": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/home",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api",
+                                "http_method": "GET",
+                                "short_description": "Show available links."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/home/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/status",
+                                "http_method": "GET",
+                                "short_description": "Show status."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/home/status",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "status",
+                        "params": [],
+                        "see": []
+                    }
+                ],
+                "name": "Home",
+                "short_description": null,
+                "version": "v2"
+            },
+            "host_classes": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/host_classes",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/puppetclass_ids",
+                                "http_method": "GET",
+                                "short_description": "List all puppetclass id's for host"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/host_classes/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/puppetclass_ids",
+                                "http_method": "POST",
+                                "short_description": "Add a puppetclass to host"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/host_classes/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of puppetclass</p>\n",
+                                "expected_type": "string",
+                                "full_name": "puppetclass_id",
+                                "name": "puppetclass_id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/puppetclass_ids/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Remove a puppetclass from host"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/host_classes/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of puppetclass</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Host classes",
+                "short_description": null,
+                "version": "v2"
+            },
+            "hostgroup_classes": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/hostgroup_classes",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/puppetclass_ids",
+                                "http_method": "GET",
+                                "short_description": "List all puppetclass id's for hostgroup"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hostgroup_classes/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/puppetclass_ids",
+                                "http_method": "POST",
+                                "short_description": "Add a puppetclass to hostgroup"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hostgroup_classes/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of hostgroup</p>\n",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of puppetclass</p>\n",
+                                "expected_type": "string",
+                                "full_name": "puppetclass_id",
+                                "name": "puppetclass_id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/puppetclass_ids/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Remove a puppetclass from hostgroup"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hostgroup_classes/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of hostgroup</p>\n",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of puppetclass</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Hostgroup classes",
+                "short_description": null,
+                "version": "v2"
+            },
+            "hostgroups": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/hostgroups",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hostgroups",
+                                "http_method": "GET",
+                                "short_description": "List all hostgroups."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hostgroups/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hostgroups/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a hostgroup."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hostgroups/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hostgroups",
+                                "http_method": "POST",
+                                "short_description": "Create an hostgroup."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hostgroups/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "hostgroup",
+                                "name": "hostgroup",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[parent_id]",
+                                        "name": "parent_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[environment_id]",
+                                        "name": "environment_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[operatingsystem_id]",
+                                        "name": "operatingsystem_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[architecture_id]",
+                                        "name": "architecture_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[medium_id]",
+                                        "name": "medium_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[ptable_id]",
+                                        "name": "ptable_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[puppet_ca_proxy_id]",
+                                        "name": "puppet_ca_proxy_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[subnet_id]",
+                                        "name": "subnet_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[domain_id]",
+                                        "name": "domain_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[puppet_proxy_id]",
+                                        "name": "puppet_proxy_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hostgroups/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update an hostgroup."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hostgroups/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "hostgroup",
+                                "name": "hostgroup",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[parent_id]",
+                                        "name": "parent_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[environment_id]",
+                                        "name": "environment_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[operatingsystem_id]",
+                                        "name": "operatingsystem_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[architecture_id]",
+                                        "name": "architecture_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[medium_id]",
+                                        "name": "medium_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[ptable_id]",
+                                        "name": "ptable_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[puppet_ca_proxy_id]",
+                                        "name": "puppet_ca_proxy_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[subnet_id]",
+                                        "name": "subnet_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[domain_id]",
+                                        "name": "domain_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "hostgroup[puppet_proxy_id]",
+                                        "name": "puppet_proxy_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hostgroups/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an hostgroup."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hostgroups/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Hostgroups",
+                "short_description": null,
+                "version": "v2"
+            },
+            "hosts": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/hosts",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts",
+                                "http_method": "GET",
+                                "short_description": "List all hosts."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hosts/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a host."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hosts/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts",
+                                "http_method": "POST",
+                                "short_description": "Create a host."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hosts/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "host",
+                                "name": "host",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[environment_id]",
+                                        "name": "environment_id",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>not required if using a subnet with dhcp proxy</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "host[ip]",
+                                        "name": "ip",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>not required if its a virtual machine</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "host[mac]",
+                                        "name": "mac",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[architecture_id]",
+                                        "name": "architecture_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[domain_id]",
+                                        "name": "domain_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[puppet_proxy_id]",
+                                        "name": "puppet_proxy_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "array",
+                                        "full_name": "host[puppet_class_ids]",
+                                        "name": "puppet_class_ids",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[operatingsystem_id]",
+                                        "name": "operatingsystem_id",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[medium_id]",
+                                        "name": "medium_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[ptable_id]",
+                                        "name": "ptable_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[subnet_id]",
+                                        "name": "subnet_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[compute_resource_id]",
+                                        "name": "compute_resource_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[sp_subnet_id]",
+                                        "name": "sp_subnet_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[model_id]",
+                                        "name": "model_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[hostgroup_id]",
+                                        "name": "hostgroup_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[owner_id]",
+                                        "name": "owner_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[puppet_ca_proxy_id]",
+                                        "name": "puppet_ca_proxy_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[image_id]",
+                                        "name": "image_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "array",
+                                        "full_name": "host[host_parameters_attributes]",
+                                        "name": "host_parameters_attributes",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[build]",
+                                        "name": "build",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[enabled]",
+                                        "name": "enabled",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[provision_method]",
+                                        "name": "provision_method",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[managed]",
+                                        "name": "managed",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>UUID to track orchestration tasks status, GET\n/api/orchestration/:UUID/tasks</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "host[progress_report_id]",
+                                        "name": "progress_report_id",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[capabilities]",
+                                        "name": "capabilities",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "hash",
+                                        "full_name": "host[compute_attributes]",
+                                        "name": "compute_attributes",
+                                        "params": [],
+                                        "required": false,
+                                        "validator": "Must be a Hash"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a host."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hosts/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "host",
+                                "name": "host",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[environment_id]",
+                                        "name": "environment_id",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>not required if using a subnet with dhcp proxy</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "host[ip]",
+                                        "name": "ip",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>not required if its a virtual machine</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "host[mac]",
+                                        "name": "mac",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[architecture_id]",
+                                        "name": "architecture_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[domain_id]",
+                                        "name": "domain_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[puppet_proxy_id]",
+                                        "name": "puppet_proxy_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "array",
+                                        "full_name": "host[puppet_class_ids]",
+                                        "name": "puppet_class_ids",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[operatingsystem_id]",
+                                        "name": "operatingsystem_id",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[medium_id]",
+                                        "name": "medium_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[ptable_id]",
+                                        "name": "ptable_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[subnet_id]",
+                                        "name": "subnet_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[compute_resource_id]",
+                                        "name": "compute_resource_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[sp_subnet_id]",
+                                        "name": "sp_subnet_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[model_id]",
+                                        "name": "model_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[hostgroup_id]",
+                                        "name": "hostgroup_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[owner_id]",
+                                        "name": "owner_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[puppet_ca_proxy_id]",
+                                        "name": "puppet_ca_proxy_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[image_id]",
+                                        "name": "image_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "array",
+                                        "full_name": "host[host_parameters_attributes]",
+                                        "name": "host_parameters_attributes",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[build]",
+                                        "name": "build",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[enabled]",
+                                        "name": "enabled",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[provision_method]",
+                                        "name": "provision_method",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[managed]",
+                                        "name": "managed",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>UUID to track orchestration tasks status, GET\n/api/orchestration/:UUID/tasks</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "host[progress_report_id]",
+                                        "name": "progress_report_id",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "host[capabilities]",
+                                        "name": "capabilities",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "hash",
+                                        "full_name": "host[compute_attributes]",
+                                        "name": "compute_attributes",
+                                        "params": [],
+                                        "required": false,
+                                        "validator": "Must be a Hash"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an host."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hosts/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:id/status",
+                                "http_method": "GET",
+                                "short_description": "Get status of host"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hosts/status",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "\n<p>Return value may either be one of the following:</p>\n<ul><li>\n<p>missing</p>\n</li><li>\n<p>failed</p>\n</li><li>\n<p>pending</p>\n</li><li>\n<p>changed</p>\n</li><li>\n<p>unchanged</p>\n</li><li>\n<p>unreported</p>\n</li></ul>\n",
+                        "name": "status",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:id/puppetrun",
+                                "http_method": "PUT",
+                                "short_description": "Force a puppet run on the agent."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hosts/puppetrun",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "puppetrun",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:id/power",
+                                "http_method": "PUT",
+                                "short_description": "Run power operation on host."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hosts/power",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "power",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>power action, valid actions are ('on', 'start')', ('off', 'stop'), ('soft',\n'reboot'), ('cycle', 'reset'), ('state', 'status')</p>\n",
+                                "expected_type": "string",
+                                "full_name": "power_action",
+                                "name": "power_action",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:id/boot",
+                                "http_method": "PUT",
+                                "short_description": "Boot host from specified device."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hosts/boot",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "boot",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>boot device, valid devices are disk, cdrom, pxe, bios</p>\n",
+                                "expected_type": "string",
+                                "full_name": "device",
+                                "name": "device",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/facts",
+                                "http_method": "POST",
+                                "short_description": "Upload facts for a host, creating the host if required."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/hosts/facts",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "facts",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>hostname of the host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "name",
+                                "name": "name",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>hash containing the facts for the host</p>\n",
+                                "expected_type": "hash",
+                                "full_name": "facts",
+                                "name": "facts",
+                                "required": true,
+                                "validator": "Must be Hash"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>optional: certname of the host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "certname",
+                                "name": "certname",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>optional: the STI type of host to create</p>\n",
+                                "expected_type": "string",
+                                "full_name": "type",
+                                "name": "type",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Hosts",
+                "short_description": null,
+                "version": "v2"
+            },
+            "images": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/images",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources/:compute_resource_id/images",
+                                "http_method": "GET",
+                                "short_description": "List all images for compute resource"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/images/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "compute_resource_id",
+                                "name": "compute_resource_id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an image"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/images/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "compute_resource_id",
+                                "name": "compute_resource_id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources/:compute_resource_id/images",
+                                "http_method": "POST",
+                                "short_description": "Create a image"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/images/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "compute_resource_id",
+                                "name": "compute_resource_id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "image",
+                                "name": "image",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[username]",
+                                        "name": "username",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[uuid]",
+                                        "name": "uuid",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[compute_resource_id]",
+                                        "name": "compute_resource_id",
+                                        "required": true,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[architecture_id]",
+                                        "name": "architecture_id",
+                                        "required": true,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[operatingsystem_id]",
+                                        "name": "operatingsystem_id",
+                                        "required": true,
+                                        "validator": "Must be a number."
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a image."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/images/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "compute_resource_id",
+                                "name": "compute_resource_id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "image",
+                                "name": "image",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[username]",
+                                        "name": "username",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[uuid]",
+                                        "name": "uuid",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[compute_resource_id]",
+                                        "name": "compute_resource_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[architecture_id]",
+                                        "name": "architecture_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "image[operatingsystem_id]",
+                                        "name": "operatingsystem_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an image."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/images/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "compute_resource_id",
+                                "name": "compute_resource_id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Images",
+                "short_description": null,
+                "version": "v2"
+            },
+            "interfaces": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/interfaces",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/interfaces",
+                                "http_method": "GET",
+                                "short_description": "List all interfaces for host"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/interfaces/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id or name of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/interfaces/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an interface for host"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/interfaces/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id or name of nested host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id or name of interface</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/interfaces",
+                                "http_method": "POST",
+                                "short_description": "Create an interface linked to a host"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/interfaces/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id or name of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "\n<p>interface information</p>\n",
+                                "expected_type": "hash",
+                                "full_name": "interface",
+                                "name": "interface",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>MAC address of interface</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "interface[mac]",
+                                        "name": "mac",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>IP address of interface</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "interface[ip]",
+                                        "name": "ip",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Interface type, i.e: Nic::BMC</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "interface[type]",
+                                        "name": "type",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Interface name</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "interface[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Foreman subnet id of interface</p>\n",
+                                        "expected_type": "numeric",
+                                        "full_name": "interface[subnet_id]",
+                                        "name": "subnet_id",
+                                        "required": false,
+                                        "validator": "Must be Fixnum"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Foreman domain id of interface</p>\n",
+                                        "expected_type": "numeric",
+                                        "full_name": "interface[domain_id]",
+                                        "name": "domain_id",
+                                        "required": false,
+                                        "validator": "Must be Fixnum"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "interface[username]",
+                                        "name": "username",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "interface[password]",
+                                        "name": "password",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Interface provider, i.e: IPMI</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "interface[provider]",
+                                        "name": "provider",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/interfaces/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update host interface"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/interfaces/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id or name of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "\n<p>interface information</p>\n",
+                                "expected_type": "hash",
+                                "full_name": "interface",
+                                "name": "interface",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>MAC address of interface</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "interface[mac]",
+                                        "name": "mac",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>IP address of interface</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "interface[ip]",
+                                        "name": "ip",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Interface type, i.e: Nic::BMC</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "interface[type]",
+                                        "name": "type",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Interface name</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "interface[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Foreman subnet id of interface</p>\n",
+                                        "expected_type": "numeric",
+                                        "full_name": "interface[subnet_id]",
+                                        "name": "subnet_id",
+                                        "required": false,
+                                        "validator": "Must be Fixnum"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Foreman domain id of interface</p>\n",
+                                        "expected_type": "numeric",
+                                        "full_name": "interface[domain_id]",
+                                        "name": "domain_id",
+                                        "required": false,
+                                        "validator": "Must be Fixnum"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "interface[username]",
+                                        "name": "username",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "interface[password]",
+                                        "name": "password",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Interface provider, i.e: IPMI</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "interface[provider]",
+                                        "name": "provider",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/interfaces/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a host interface"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/interfaces/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of interface</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Interfaces",
+                "short_description": null,
+                "version": "v2"
+            },
+            "locations": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/locations",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/locations",
+                                "http_method": "GET",
+                                "short_description": "List all locations"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/locations/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/locations/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a location"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/locations/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/locations",
+                                "http_method": "POST",
+                                "short_description": "Create a location"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/locations/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "location",
+                                "name": "location",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "location[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/locations/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a location"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/locations/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "location",
+                                "name": "location",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "location[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/locations/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a location"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/locations/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [],
+                        "see": []
+                    }
+                ],
+                "name": "Locations",
+                "short_description": null,
+                "version": "v2"
+            },
+            "media": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/media",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/media",
+                                "http_method": "GET",
+                                "short_description": "List all media."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/media/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>for example, name ASC, or name DESC</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/media/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a medium."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/media/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/media",
+                                "http_method": "POST",
+                                "short_description": "Create a medium."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/media/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "medium",
+                                "name": "medium",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Name of media</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "medium[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>The path to the medium, can be a URL or a valid NFS server (exclusive of\nthe architecture).</p>\n\n<p>for example <a\nhref=\"http://mirror.centos.org/centos/$version/os/$arch\">mirror.centos.org/centos/$version/os/$arch</a>\nwhere $arch will be substituted for the host's actual OS architecture and\n$version, $major and $minor will be substituted for the version of the\noperating system.</p>\n\n<p>Solaris and Debian media may also use $release.</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "medium[path]",
+                                        "name": "path",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>The family that the operating system belongs to.</p>\n\n<p>Available families:</p>\n<ul><li>\n<p>AIX</p>\n</li><li>\n<p>Archlinux</p>\n</li><li>\n<p>Debian</p>\n</li><li>\n<p>Freebsd</p>\n</li><li>\n<p>Gentoo</p>\n</li><li>\n<p>Junos</p>\n</li><li>\n<p>Redhat</p>\n</li><li>\n<p>Solaris</p>\n</li><li>\n<p>Suse</p>\n</li><li>\n<p>Windows</p>\n</li></ul>\n",
+                                        "expected_type": "string",
+                                        "full_name": "medium[os_family]",
+                                        "name": "os_family",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "array",
+                                        "full_name": "medium[operatingsystem_ids]",
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/media/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a medium."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/media/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "medium",
+                                "name": "medium",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Name of media</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "medium[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>The path to the medium, can be a URL or a valid NFS server (exclusive of\nthe architecture).</p>\n\n<p>for example <a\nhref=\"http://mirror.centos.org/centos/$version/os/$arch\">mirror.centos.org/centos/$version/os/$arch</a>\nwhere $arch will be substituted for the host's actual OS architecture and\n$version, $major and $minor will be substituted for the version of the\noperating system.</p>\n\n<p>Solaris and Debian media may also use $release.</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "medium[path]",
+                                        "name": "path",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>The family that the operating system belongs to.</p>\n\n<p>Available families:</p>\n<ul><li>\n<p>AIX</p>\n</li><li>\n<p>Archlinux</p>\n</li><li>\n<p>Debian</p>\n</li><li>\n<p>Freebsd</p>\n</li><li>\n<p>Gentoo</p>\n</li><li>\n<p>Junos</p>\n</li><li>\n<p>Redhat</p>\n</li><li>\n<p>Solaris</p>\n</li><li>\n<p>Suse</p>\n</li><li>\n<p>Windows</p>\n</li></ul>\n",
+                                        "expected_type": "string",
+                                        "full_name": "medium[os_family]",
+                                        "name": "os_family",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "array",
+                                        "full_name": "medium[operatingsystem_ids]",
+                                        "name": "operatingsystem_ids",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/media/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a medium."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/media/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Media",
+                "short_description": null,
+                "version": "v2"
+            },
+            "models": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/models",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/models",
+                                "http_method": "GET",
+                                "short_description": "List all models."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/models/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/models/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a model."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/models/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/models",
+                                "http_method": "POST",
+                                "short_description": "Create a model."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/models/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "model",
+                                "name": "model",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "model[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "model[info]",
+                                        "name": "info",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "model[vendor_class]",
+                                        "name": "vendor_class",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "model[hardware_model]",
+                                        "name": "hardware_model",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/models/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a model."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/models/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "model",
+                                "name": "model",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "model[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "model[info]",
+                                        "name": "info",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "model[vendor_class]",
+                                        "name": "vendor_class",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "model[hardware_model]",
+                                        "name": "hardware_model",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/models/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a model."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/models/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Models",
+                "short_description": null,
+                "version": "v2"
+            },
+            "operatingsystems": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/operatingsystems",
+                "formats": null,
+                "full_description": "",
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems",
+                                "http_method": "GET",
+                                "short_description": "List all operating systems."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/operatingsystems/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>for example, name ASC, or name DESC</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an OS."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/operatingsystems/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems",
+                                "http_method": "POST",
+                                "short_description": "Create an OS."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/operatingsystems/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "operatingsystem",
+                                "name": "operatingsystem",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must match regular expression /\\A(\\S+)\\Z/."
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[major]",
+                                        "name": "major",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[minor]",
+                                        "name": "minor",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[description]",
+                                        "name": "description",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[family]",
+                                        "name": "family",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[release_name]",
+                                        "name": "release_name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update an OS."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/operatingsystems/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "operatingsystem",
+                                "name": "operatingsystem",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must match regular expression /\\A(\\S+)\\Z/."
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[major]",
+                                        "name": "major",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[minor]",
+                                        "name": "minor",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[description]",
+                                        "name": "description",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[family]",
+                                        "name": "family",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "operatingsystem[release_name]",
+                                        "name": "release_name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an OS."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/operatingsystems/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems/:id/bootfiles",
+                                "http_method": "GET",
+                                "short_description": "List boot files an OS."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/operatingsystems/bootfiles",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "bootfiles",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "medium",
+                                "name": "medium",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "architecture",
+                                "name": "architecture",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Operating systems",
+                "short_description": null,
+                "version": "v2"
+            },
+            "organizations": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/organizations",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/organizations",
+                                "http_method": "GET",
+                                "short_description": "List all organizations"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/organizations/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/organizations/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an organization"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/organizations/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/organizations",
+                                "http_method": "POST",
+                                "short_description": "Create an organization"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/organizations/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "organization",
+                                "name": "organization",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "organization[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/organizations/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update an organization"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/organizations/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "organization",
+                                "name": "organization",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "organization[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/organizations/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an organization"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/organizations/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [],
+                        "see": []
+                    }
+                ],
+                "name": "Organizations",
+                "short_description": null,
+                "version": "v2"
+            },
+            "os_default_templates": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/os_default_templates",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/os_default_templates",
+                                "http_method": "GET",
+                                "short_description": "List os default templates for operating system"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/os_default_templates/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/os_default_templates/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a os default template kind for operating system"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/os_default_templates/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be a number."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/os_default_templates",
+                                "http_method": "POST",
+                                "short_description": "Create a os default template for operating system"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/os_default_templates/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "os_default_template",
+                                "name": "os_default_template",
+                                "params": [
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "os_default_template[template_kind_id]",
+                                        "name": "template_kind_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "os_default_template[config_template_id]",
+                                        "name": "config_template_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/os_default_templates/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a os default template for operating system"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/os_default_templates/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "os_default_template",
+                                "name": "os_default_template",
+                                "params": [
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "os_default_template[template_kind_id]",
+                                        "name": "template_kind_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "os_default_template[config_template_id]",
+                                        "name": "config_template_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/os_default_templates/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a os default template for operating system"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/os_default_templates/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Os default templates",
+                "short_description": null,
+                "version": "v2"
+            },
+            "override_values": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/override_values",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_variables/:smart_variable_id/override_values",
+                                "http_method": "GET",
+                                "short_description": "List of override values for a specific smart_variable"
+                            },
+                            {
+                                "api_url": "/api/smart_class_parameters/:smart_class_parameter_id/override_values",
+                                "http_method": "GET",
+                                "short_description": "List of override values for a specific smart class parameter"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/override_values/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "smart_variable_id",
+                                "name": "smart_variable_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "smart_class_parameter_id",
+                                "name": "smart_class_parameter_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_variables/:smart_variable_id/override_values/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an override value for a specific smart_variable"
+                            },
+                            {
+                                "api_url": "/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an override value for a specific smart class parameter"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/override_values/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "smart_variable_id",
+                                "name": "smart_variable_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "smart_class_parameter_id",
+                                "name": "smart_class_parameter_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_variables/:smart_variable_id/override_values",
+                                "http_method": "POST",
+                                "short_description": "Create an override value for a specific smart_variable"
+                            },
+                            {
+                                "api_url": "/api/smart_class_parameters/:smart_class_parameter_id/override_values",
+                                "http_method": "POST",
+                                "short_description": "Create an override value for a specific smart class parameter"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/override_values/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "smart_variable_id",
+                                "name": "smart_variable_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "override_value",
+                                "name": "override_value",
+                                "params": [
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "override_value[match]",
+                                        "name": "match",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "override_value[value]",
+                                        "name": "value",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_variables/:smart_variable_id/override_values/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update an override value for a specific smart_variable"
+                            },
+                            {
+                                "api_url": "/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update an override value for a specific smart class parameter"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/override_values/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "override_value",
+                                "name": "override_value",
+                                "params": [
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "override_value[match]",
+                                        "name": "match",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "override_value[value]",
+                                        "name": "value",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_variables/:smart_variable_id/override_values/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an override value for a specific smart_variable"
+                            },
+                            {
+                                "api_url": "/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an override value for a specific smart class parameter"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/override_values/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Override values",
+                "short_description": null,
+                "version": "v2"
+            },
+            "parameters": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/parameters",
+                "formats": null,
+                "full_description": "\n<p>These API calls are related to <strong>nested parameters for host, domain,\nhostgroup, operating system</strong>. If you are looking for &lt;a\nhref=\"common_parameters.html\"&gt;global parameters&lt;/a&gt;, go to &lt;a\nhref=\"common_parameters.html\"&gt;this link&lt;/a&gt;.</p>\n",
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/parameters",
+                                "http_method": "GET",
+                                "short_description": "List all parameters for host"
+                            },
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters",
+                                "http_method": "GET",
+                                "short_description": "List all parameters for hostgroup"
+                            },
+                            {
+                                "api_url": "/api/domains/:domain_id/parameters",
+                                "http_method": "GET",
+                                "short_description": "List all parameters for domain"
+                            },
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters",
+                                "http_method": "GET",
+                                "short_description": "List all parameters for operating system"
+                            },
+                            {
+                                "api_url": "/api/locations/:location_id/parameters",
+                                "http_method": "GET",
+                                "short_description": "List all parameters for location"
+                            },
+                            {
+                                "api_url": "/api/organizations/:organization_id/parameters",
+                                "http_method": "GET",
+                                "short_description": "List all parameters for organization"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/parameters/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of hostgroup</p>\n",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of domain</p>\n",
+                                "expected_type": "string",
+                                "full_name": "domain_id",
+                                "name": "domain_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of location</p>\n",
+                                "expected_type": "string",
+                                "full_name": "location_id",
+                                "name": "location_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of organization</p>\n",
+                                "expected_type": "string",
+                                "full_name": "organization_id",
+                                "name": "organization_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/parameters/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a nested parameter for host"
+                            },
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a nested parameter for hostgroup"
+                            },
+                            {
+                                "api_url": "/api/domains/:domain_id/parameters/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a nested parameter for domain"
+                            },
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a nested parameter for operating system"
+                            },
+                            {
+                                "api_url": "/api/locations/:location_id/parameters/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a nested parameter for location"
+                            },
+                            {
+                                "api_url": "/api/organizations/:organization_id/parameters/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a nested parameter for organization"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/parameters/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of hostgroup</p>\n",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of domain</p>\n",
+                                "expected_type": "string",
+                                "full_name": "domain_id",
+                                "name": "domain_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of location</p>\n",
+                                "expected_type": "string",
+                                "full_name": "location_id",
+                                "name": "location_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of organization</p>\n",
+                                "expected_type": "string",
+                                "full_name": "organization_id",
+                                "name": "organization_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of parameter</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/parameters",
+                                "http_method": "POST",
+                                "short_description": "Create a nested parameter for host"
+                            },
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters",
+                                "http_method": "POST",
+                                "short_description": "Create a nested parameter for hostgroup"
+                            },
+                            {
+                                "api_url": "/api/domains/:domain_id/parameters",
+                                "http_method": "POST",
+                                "short_description": "Create a nested parameter for domain"
+                            },
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters",
+                                "http_method": "POST",
+                                "short_description": "Create a nested parameter for operating system"
+                            },
+                            {
+                                "api_url": "/api/locations/:location_id/parameters",
+                                "http_method": "POST",
+                                "short_description": "Create a nested parameter for location"
+                            },
+                            {
+                                "api_url": "/api/organizations/:organization_id/parameters",
+                                "http_method": "POST",
+                                "short_description": "Create a nested parameter for organization"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/parameters/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of hostgroup</p>\n",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of domain</p>\n",
+                                "expected_type": "string",
+                                "full_name": "domain_id",
+                                "name": "domain_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of location</p>\n",
+                                "expected_type": "string",
+                                "full_name": "location_id",
+                                "name": "location_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of organization</p>\n",
+                                "expected_type": "string",
+                                "full_name": "organization_id",
+                                "name": "organization_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "parameter",
+                                "name": "parameter",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "parameter[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "parameter[value]",
+                                        "name": "value",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/parameters/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a nested parameter for host"
+                            },
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a nested parameter for hostgroup"
+                            },
+                            {
+                                "api_url": "/api/domains/:domain_id/parameters/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a nested parameter for domain"
+                            },
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a nested parameter for operating system"
+                            },
+                            {
+                                "api_url": "/api/locations/:location_id/parameters/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a nested parameter for location"
+                            },
+                            {
+                                "api_url": "/api/organizations/:organization_id/parameters/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a nested parameter for organization"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/parameters/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of hostgroup</p>\n",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of domain</p>\n",
+                                "expected_type": "string",
+                                "full_name": "domain_id",
+                                "name": "domain_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of location</p>\n",
+                                "expected_type": "string",
+                                "full_name": "location_id",
+                                "name": "location_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of organization</p>\n",
+                                "expected_type": "string",
+                                "full_name": "organization_id",
+                                "name": "organization_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of parameter</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "parameter",
+                                "name": "parameter",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "parameter[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "parameter[value]",
+                                        "name": "value",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/parameters/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a nested parameter for host"
+                            },
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a nested parameter for hostgroup"
+                            },
+                            {
+                                "api_url": "/api/domains/:domain_id/parameters/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a nested parameter for domain"
+                            },
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a nested parameter for operating system"
+                            },
+                            {
+                                "api_url": "/api/locations/:location_id/parameters/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a nested parameter for location"
+                            },
+                            {
+                                "api_url": "/api/organizations/:organization_id/parameters/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a nested parameter for organization"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/parameters/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of hostgroup</p>\n",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of domain</p>\n",
+                                "expected_type": "string",
+                                "full_name": "domain_id",
+                                "name": "domain_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of location</p>\n",
+                                "expected_type": "string",
+                                "full_name": "location_id",
+                                "name": "location_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of organization</p>\n",
+                                "expected_type": "string",
+                                "full_name": "organization_id",
+                                "name": "organization_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of parameter</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/parameters",
+                                "http_method": "DELETE",
+                                "short_description": "Delete all nested parameters for host"
+                            },
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters",
+                                "http_method": "DELETE",
+                                "short_description": "Delete all nested parameters for hostgroup"
+                            },
+                            {
+                                "api_url": "/api/domains/:domain_id/parameters",
+                                "http_method": "DELETE",
+                                "short_description": "Delete all nested parameters for domain"
+                            },
+                            {
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters",
+                                "http_method": "DELETE",
+                                "short_description": "Delete all nested parameters for operating system"
+                            },
+                            {
+                                "api_url": "/api/locations/:location_id/parameters",
+                                "http_method": "DELETE",
+                                "short_description": "Delete all nested parameter for location"
+                            },
+                            {
+                                "api_url": "/api/organizations/:organization_id/parameters",
+                                "http_method": "DELETE",
+                                "short_description": "Delete all nested parameter for organization"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/parameters/reset",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "reset",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of hostgroup</p>\n",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of domain</p>\n",
+                                "expected_type": "string",
+                                "full_name": "domain_id",
+                                "name": "domain_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of operating system</p>\n",
+                                "expected_type": "string",
+                                "full_name": "operatingsystem_id",
+                                "name": "operatingsystem_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of location</p>\n",
+                                "expected_type": "string",
+                                "full_name": "location_id",
+                                "name": "location_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of organization</p>\n",
+                                "expected_type": "string",
+                                "full_name": "organization_id",
+                                "name": "organization_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Parameters",
+                "short_description": null,
+                "version": "v2"
+            },
+            "plugins": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/plugins",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/plugins",
+                                "http_method": "GET",
+                                "short_description": "List of installed plugins"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/plugins/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [],
+                        "see": []
+                    }
+                ],
+                "name": "Plugins",
+                "short_description": null,
+                "version": "v2"
+            },
+            "ptables": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/ptables",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/ptables",
+                                "http_method": "GET",
+                                "short_description": "List all ptables."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/ptables/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/ptables/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a ptable."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/ptables/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/ptables",
+                                "http_method": "POST",
+                                "short_description": "Create a ptable."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/ptables/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "ptable",
+                                "name": "ptable",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "ptable[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "ptable[layout]",
+                                        "name": "layout",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "ptable[os_family]",
+                                        "name": "os_family",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/ptables/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a ptable."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/ptables/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "ptable",
+                                "name": "ptable",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "ptable[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "ptable[layout]",
+                                        "name": "layout",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "ptable[os_family]",
+                                        "name": "os_family",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/ptables/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a ptable."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/ptables/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Ptables",
+                "short_description": null,
+                "version": "v2"
+            },
+            "puppetclasses": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/puppetclasses",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/puppetclasses",
+                                "http_method": "GET",
+                                "short_description": "List all puppetclasses."
+                            },
+                            {
+                                "api_url": "/api/hosts/:host_id/puppetclasses",
+                                "http_method": "GET",
+                                "short_description": "List all puppetclasses for host"
+                            },
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/puppetclasses",
+                                "http_method": "GET",
+                                "short_description": "List all puppetclasses for hostgroup"
+                            },
+                            {
+                                "api_url": "/api/environments/:environment_id/puppetclasses",
+                                "http_method": "GET",
+                                "short_description": "List all puppetclasses for environment"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/puppetclasses/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of nested host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of nested hostgroup</p>\n",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of nested environment</p>\n",
+                                "expected_type": "string",
+                                "full_name": "environment_id",
+                                "name": "environment_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/puppetclasses/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a puppetclass"
+                            },
+                            {
+                                "api_url": "/api/hosts/:host_id/puppetclasses/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a puppetclass for host"
+                            },
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/puppetclasses/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a puppetclass for hostgroup"
+                            },
+                            {
+                                "api_url": "/api/environments/:environment_id/puppetclasses/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a puppetclass for environment"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/puppetclasses/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of nested host</p>\n",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of nested hostgroup</p>\n",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of nested environment</p>\n",
+                                "expected_type": "string",
+                                "full_name": "environment_id",
+                                "name": "environment_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>id of puppetclass</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/puppetclasses",
+                                "http_method": "POST",
+                                "short_description": "Create a puppetclass."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/puppetclasses/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "puppetclass",
+                                "name": "puppetclass",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "puppetclass[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/puppetclasses/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a puppetclass."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/puppetclasses/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "puppetclass",
+                                "name": "puppetclass",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "puppetclass[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/puppetclasses/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a puppetclass."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/puppetclasses/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Puppetclasses",
+                "short_description": null,
+                "version": "v2"
+            },
+            "reports": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/reports",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/reports",
+                                "http_method": "GET",
+                                "short_description": "List all reports."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/reports/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/reports/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a report."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/reports/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/reports",
+                                "http_method": "POST",
+                                "short_description": "Create a report."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/reports/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "report",
+                                "name": "report",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Hostname or certname</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "report[host]",
+                                        "name": "host",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>UTC time of report</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "report[reported_at]",
+                                        "name": "reported_at",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Hash of status type totals</p>\n",
+                                        "expected_type": "hash",
+                                        "full_name": "report[status]",
+                                        "name": "status",
+                                        "required": true,
+                                        "validator": "Must be Hash"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Hash of report metrics, can be just {}</p>\n",
+                                        "expected_type": "hash",
+                                        "full_name": "report[metrics]",
+                                        "name": "metrics",
+                                        "required": true,
+                                        "validator": "Must be Hash"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Optional array of log hashes</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "report[logs]",
+                                        "name": "logs",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/reports/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a report."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/reports/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/hosts/:host_id/reports/last",
+                                "http_method": "GET",
+                                "short_description": "Show the last report for a given host."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/reports/last",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "last",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Reports",
+                "short_description": null,
+                "version": "v2"
+            },
+            "roles": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/roles",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/roles",
+                                "http_method": "GET",
+                                "short_description": "List all roles."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/roles/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/roles/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an role."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/roles/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/roles",
+                                "http_method": "POST",
+                                "short_description": "Create an role."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/roles/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "role",
+                                "name": "role",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "role[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/roles/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update an role."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/roles/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "role",
+                                "name": "role",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "role[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/roles/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an role."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/roles/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Roles",
+                "short_description": null,
+                "version": "v2"
+            },
+            "settings": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/settings",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/settings",
+                                "http_method": "GET",
+                                "short_description": "List all settings."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/settings/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/settings/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an setting."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/settings/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/settings/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a setting."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/settings/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "setting",
+                                "name": "setting",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "setting[value]",
+                                        "name": "value",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": true,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Settings",
+                "short_description": null,
+                "version": "v2"
+            },
+            "smart_class_parameters": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/smart_class_parameters",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_class_parameters",
+                                "http_method": "GET",
+                                "short_description": "List all smart class parameters"
+                            },
+                            {
+                                "api_url": "/api/hosts/:host_id/smart_class_parameters",
+                                "http_method": "GET",
+                                "short_description": "List of smart class parameters for a specific host"
+                            },
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/smart_class_parameters",
+                                "http_method": "GET",
+                                "short_description": "List of smart class parameters for a specific hostgroup"
+                            },
+                            {
+                                "api_url": "/api/puppetclasses/:puppetclass_id/smart_class_parameters",
+                                "http_method": "GET",
+                                "short_description": "List of smart class parameters for a specific puppetclass"
+                            },
+                            {
+                                "api_url": "/api/environments/:environment_id/smart_class_parameters",
+                                "http_method": "GET",
+                                "short_description": "List of smart class parameters for a specific environment"
+                            },
+                            {
+                                "api_url": "/api/environments/:environment_id/puppetclasses/:puppetclass_id/smart_class_parameters",
+                                "http_method": "GET",
+                                "short_description": "List of smart class parameters for a specific environment/puppetclass combination"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_class_parameters/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "puppetclass_id",
+                                "name": "puppetclass_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "environment_id",
+                                "name": "environment_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_class_parameters/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a smart class parameter."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_class_parameters/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_class_parameters/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a smart class parameter."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_class_parameters/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "smart_class_parameter",
+                                "name": "smart_class_parameter",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_class_parameter[override]",
+                                        "name": "override",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_class_parameter[description]",
+                                        "name": "description",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_class_parameter[default_value]",
+                                        "name": "default_value",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_class_parameter[path]",
+                                        "name": "path",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_class_parameter[validator_type]",
+                                        "name": "validator_type",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_class_parameter[validator_rule]",
+                                        "name": "validator_rule",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_class_parameter[override_value_order]",
+                                        "name": "override_value_order",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_class_parameter[parameter_type]",
+                                        "name": "parameter_type",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_class_parameter[required]",
+                                        "name": "required",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    }
+                                ],
+                                "required": true,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Smart class parameters",
+                "short_description": null,
+                "version": "v2"
+            },
+            "smart_proxies": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/smart_proxies",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_proxies/:id/import_puppetclasses",
+                                "http_method": "POST",
+                                "short_description": "Import puppet classes from puppet proxy."
+                            },
+                            {
+                                "api_url": "/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses",
+                                "http_method": "POST",
+                                "short_description": "Import puppet classes from puppet proxy for particular environment."
+                            },
+                            {
+                                "api_url": "/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses",
+                                "http_method": "POST",
+                                "short_description": "Import puppet classes from puppet proxy for particular environment."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_proxies/import_puppetclasses",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "import_puppetclasses",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "smart_proxy_id",
+                                "name": "smart_proxy_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "environment_id",
+                                "name": "environment_id",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "dryrun",
+                                "name": "dryrun",
+                                "required": false,
+                                "validator": "Must be 'true' or 'false'"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_proxies",
+                                "http_method": "GET",
+                                "short_description": "List all smart_proxies."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_proxies/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter by type</p>\n",
+                                "expected_type": "string",
+                                "full_name": "type",
+                                "name": "type",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_proxies/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a smart proxy."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_proxies/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_proxies",
+                                "http_method": "POST",
+                                "short_description": "Create a smart proxy."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_proxies/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "smart_proxy",
+                                "name": "smart_proxy",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_proxy[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_proxy[url]",
+                                        "name": "url",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_proxies/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a smart proxy."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_proxies/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "smart_proxy",
+                                "name": "smart_proxy",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_proxy[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_proxy[url]",
+                                        "name": "url",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_proxies/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a smart_proxy."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_proxies/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_proxies/:id/refresh",
+                                "http_method": "PUT",
+                                "short_description": "Refresh smart proxy features"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_proxies/refresh",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "refresh",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Smart proxies",
+                "short_description": null,
+                "version": "v2"
+            },
+            "smart_variables": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/smart_variables",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_variables",
+                                "http_method": "GET",
+                                "short_description": "List all smart variables"
+                            },
+                            {
+                                "api_url": "/api/hosts/:host_id/smart_variables",
+                                "http_method": "GET",
+                                "short_description": "List of smart variables for a specific host"
+                            },
+                            {
+                                "api_url": "/api/hostgroups/:hostgroup_id/smart_variables",
+                                "http_method": "GET",
+                                "short_description": "List of smart variables for a specific hostgroup"
+                            },
+                            {
+                                "api_url": "/api/puppetclasses/:puppetclass_id/smart_variables",
+                                "http_method": "GET",
+                                "short_description": "List of smart variables for a specific puppetclass"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_variables/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "host_id",
+                                "name": "host_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "hostgroup_id",
+                                "name": "hostgroup_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "puppetclass_id",
+                                "name": "puppetclass_id",
+                                "required": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_variables/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a smart variable."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_variables/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_variables",
+                                "http_method": "POST",
+                                "short_description": "Create a smart variable."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_variables/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "smart_variable",
+                                "name": "smart_variable",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[variable]",
+                                        "name": "variable",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[puppetclass_id]",
+                                        "name": "puppetclass_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[default_value]",
+                                        "name": "default_value",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[override_value_order]",
+                                        "name": "override_value_order",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[description]",
+                                        "name": "description",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[validator_type]",
+                                        "name": "validator_type",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[validator_rule]",
+                                        "name": "validator_rule",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[variable_type]",
+                                        "name": "variable_type",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_variables/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a smart variable."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_variables/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "smart_variable",
+                                "name": "smart_variable",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[variable]",
+                                        "name": "variable",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[puppetclass_id]",
+                                        "name": "puppetclass_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[default_value]",
+                                        "name": "default_value",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[override_value_order]",
+                                        "name": "override_value_order",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[description]",
+                                        "name": "description",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[validator_type]",
+                                        "name": "validator_type",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[validator_rule]",
+                                        "name": "validator_rule",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "smart_variable[variable_type]",
+                                        "name": "variable_type",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/smart_variables/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a smart variable."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/smart_variables/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Smart variables",
+                "short_description": null,
+                "version": "v2"
+            },
+            "statistics": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/statistics",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/statistics",
+                                "http_method": "GET",
+                                "short_description": "Get statistics"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/statistics/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [],
+                        "see": []
+                    }
+                ],
+                "name": "Statistics",
+                "short_description": null,
+                "version": "v2"
+            },
+            "subnets": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/subnets",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/subnets",
+                                "http_method": "GET",
+                                "short_description": "List of subnets"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/subnets/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/subnets/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a subnet."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/subnets/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/subnets",
+                                "http_method": "POST",
+                                "short_description": "Create a subnet"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/subnets/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "subnet",
+                                "name": "subnet",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Subnet name</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Subnet network</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[network]",
+                                        "name": "network",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Netmask for this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[mask]",
+                                        "name": "mask",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[gateway]",
+                                        "name": "gateway",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[dns_primary]",
+                                        "name": "dns_primary",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Secondary DNS for this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[dns_secondary]",
+                                        "name": "dns_secondary",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Starting IP Address for IP auto suggestion</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[from]",
+                                        "name": "from",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Ending IP Address for IP auto suggestion</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[to]",
+                                        "name": "to",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>VLAN ID for this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[vlanid]",
+                                        "name": "vlanid",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Domains in which this subnet is part</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "subnet[domain_ids]",
+                                        "name": "domain_ids",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>DHCP Proxy to use within this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[dhcp_id]",
+                                        "name": "dhcp_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>TFTP Proxy to use within this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[tftp_id]",
+                                        "name": "tftp_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>DNS Proxy to use within this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[dns_id]",
+                                        "name": "dns_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/subnets/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a subnet"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/subnets/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Subnet numeric identifier</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be a number."
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "subnet",
+                                "name": "subnet",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Subnet name</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Subnet network</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[network]",
+                                        "name": "network",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "\n<p>Netmask for this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[mask]",
+                                        "name": "mask",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[gateway]",
+                                        "name": "gateway",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[dns_primary]",
+                                        "name": "dns_primary",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Secondary DNS for this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[dns_secondary]",
+                                        "name": "dns_secondary",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Starting IP Address for IP auto suggestion</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[from]",
+                                        "name": "from",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Ending IP Address for IP auto suggestion</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[to]",
+                                        "name": "to",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>VLAN ID for this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[vlanid]",
+                                        "name": "vlanid",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Domains in which this subnet is part</p>\n",
+                                        "expected_type": "array",
+                                        "full_name": "subnet[domain_ids]",
+                                        "name": "domain_ids",
+                                        "required": false,
+                                        "validator": "Must be Array"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>DHCP Proxy to use within this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[dhcp_id]",
+                                        "name": "dhcp_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>TFTP Proxy to use within this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[tftp_id]",
+                                        "name": "tftp_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>DNS Proxy to use within this subnet</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "subnet[dns_id]",
+                                        "name": "dns_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/subnets/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a subnet"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/subnets/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Subnet numeric identifier</p>\n",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be a number."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Subnets",
+                "short_description": null,
+                "version": "v2"
+            },
+            "tasks": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/tasks",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/orchestration/:id/tasks",
+                                "http_method": "GET",
+                                "short_description": "List all tasks for a given orchestration event"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/tasks/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [],
+                        "see": []
+                    }
+                ],
+                "name": "Tasks",
+                "short_description": null,
+                "version": "v2"
+            },
+            "template_combinations": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/template_combinations",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/config_templates/:config_template_id/template_combinations",
+                                "http_method": "GET",
+                                "short_description": "List Template Combination"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/template_combinations/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "config_template_id",
+                                "name": "config_template_id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/config_templates/:config_template_id/template_combinations",
+                                "http_method": "POST",
+                                "short_description": "Add a Template Combination"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/template_combinations/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "config_template_id",
+                                "name": "config_template_id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "template_combination",
+                                "name": "template_combination",
+                                "params": [
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>environment id</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "template_combination[environment_id]",
+                                        "name": "environment_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>hostgroup id</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "template_combination[hostgroup_id]",
+                                        "name": "hostgroup_id",
+                                        "required": false,
+                                        "validator": "Must be a number."
+                                    }
+                                ],
+                                "required": true,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/template_combinations/:id",
+                                "http_method": "GET",
+                                "short_description": "Show Template Combination"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/template_combinations/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/template_combinations/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a template"
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/template_combinations/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Template combinations",
+                "short_description": null,
+                "version": "v2"
+            },
+            "template_kinds": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/template_kinds",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/template_kinds",
+                                "http_method": "GET",
+                                "short_description": "List all template kinds."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/template_kinds/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Template kinds",
+                "short_description": null,
+                "version": "v2"
+            },
+            "usergroups": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/usergroups",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/usergroups",
+                                "http_method": "GET",
+                                "short_description": "List all usergroups."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/usergroups/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/usergroups/:id",
+                                "http_method": "GET",
+                                "short_description": "Show a usergroup."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/usergroups/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space."
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/usergroups",
+                                "http_method": "POST",
+                                "short_description": "Create a usergroup."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/usergroups/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "usergroup",
+                                "name": "usergroup",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "usergroup[name]",
+                                        "name": "name",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/usergroups/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update a usergroup."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/usergroups/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "usergroup",
+                                "name": "usergroup",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "usergroup[name]",
+                                        "name": "name",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/usergroups/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete a usergroup."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/usergroups/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Usergroups",
+                "short_description": null,
+                "version": "v2"
+            },
+            "users": {
+                "api_url": "/api",
+                "doc_url": "/apidoc/v2/users",
+                "formats": null,
+                "full_description": null,
+                "methods": [
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/users",
+                                "http_method": "GET",
+                                "short_description": "List all users."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/users/index",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "index",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>filter results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "search",
+                                "name": "search",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>sort results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "order",
+                                "name": "order",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>paginate results</p>\n",
+                                "expected_type": "string",
+                                "full_name": "page",
+                                "name": "page",
+                                "required": false,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>number of entries per request</p>\n",
+                                "expected_type": "string",
+                                "full_name": "per_page",
+                                "name": "per_page",
+                                "required": false,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/users/:id",
+                                "http_method": "GET",
+                                "short_description": "Show an user."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/users/show",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "show",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/users",
+                                "http_method": "POST",
+                                "short_description": "Create an user."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/users/create",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "\n<p>Adds role 'Anonymous' to the user by default</p>\n",
+                        "name": "create",
+                        "params": [
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "user",
+                                "name": "user",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "user[login]",
+                                        "name": "login",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "user[firstname]",
+                                        "name": "firstname",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "user[lastname]",
+                                        "name": "lastname",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "user[mail]",
+                                        "name": "mail",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Is an admin account?</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "user[admin]",
+                                        "name": "admin",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "user[password]",
+                                        "name": "password",
+                                        "required": true,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "numeric",
+                                        "full_name": "user[auth_source_id]",
+                                        "name": "auth_source_id",
+                                        "required": true,
+                                        "validator": "Must be Integer"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/users/:id",
+                                "http_method": "PUT",
+                                "short_description": "Update an user."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/users/update",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "\n<p>Adds role 'Anonymous' to the user if it is not already present. Only admin\ncan set admin account.</p>\n",
+                        "name": "update",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": true,
+                                "description": "",
+                                "expected_type": "hash",
+                                "full_name": "user",
+                                "name": "user",
+                                "params": [
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "user[login]",
+                                        "name": "login",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "user[firstname]",
+                                        "name": "firstname",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "user[lastname]",
+                                        "name": "lastname",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "user[mail]",
+                                        "name": "mail",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": true,
+                                        "description": "\n<p>Is an admin account?</p>\n",
+                                        "expected_type": "string",
+                                        "full_name": "user[admin]",
+                                        "name": "admin",
+                                        "required": false,
+                                        "validator": "Must be 'true' or 'false'"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "string",
+                                        "full_name": "user[password]",
+                                        "name": "password",
+                                        "required": false,
+                                        "validator": "Must be String"
+                                    },
+                                    {
+                                        "allow_nil": false,
+                                        "description": "",
+                                        "expected_type": "numeric",
+                                        "full_name": "user[auth_source_id]",
+                                        "name": "auth_source_id",
+                                        "required": false,
+                                        "validator": "Must be Integer"
+                                    }
+                                ],
+                                "required": false,
+                                "validator": "Must be a Hash"
+                            }
+                        ],
+                        "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/users/:id",
+                                "http_method": "DELETE",
+                                "short_description": "Delete an user."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/users/destroy",
+                        "errors": [],
+                        "examples": [],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "destroy",
+                        "params": [
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "id",
+                                "name": "id",
+                                "required": true,
+                                "validator": "Must be String"
+                            }
+                        ],
+                        "see": []
+                    }
+                ],
+                "name": "Users",
+                "short_description": null,
+                "version": "v2"
+            }
+        }
+    }
+}

--- a/foreman/definitions/1.5.0-v1.json
+++ b/foreman/definitions/1.5.0-v1.json
@@ -1,0 +1,8620 @@
+{
+    "docs": {
+        "info": "\n<p>Foreman v1 is currently the default API version.</p>\n",
+        "name": "Foreman",
+        "copyright": "",
+        "doc_url": "/apidoc/v1",
+        "resources": {
+            "template_kinds": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all template kinds.",
+                                "http_method": "GET",
+                                "api_url": "/api/template_kinds"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/template_kinds/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/template_kinds",
+                "name": "Template kinds"
+            },
+            "lookup_keys": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all lookup_keys.",
+                                "http_method": "GET",
+                                "api_url": "/api/lookup_keys"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/lookup_keys/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a lookup key.",
+                                "http_method": "GET",
+                                "api_url": "/api/lookup_keys/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/lookup_keys/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a lookup key.",
+                                "http_method": "POST",
+                                "api_url": "/api/lookup_keys"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "lookup_key",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "key",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[key]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppetclass_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "lookup_key[puppetclass_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "default_value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[default_value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "path",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[path]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "lookup_values_count",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "lookup_key[lookup_values_count]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "lookup_key",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/lookup_keys/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a lookup key.",
+                                "http_method": "PUT",
+                                "api_url": "/api/lookup_keys/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "lookup_key",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "key",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[key]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppetclass_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "lookup_key[puppetclass_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "default_value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[default_value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "path",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[path]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "lookup_key[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "lookup_values_count",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "lookup_key[lookup_values_count]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "lookup_key",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/lookup_keys/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a lookup key.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/lookup_keys/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/lookup_keys/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/lookup_keys",
+                "name": "Lookup keys"
+            },
+            "hostgroups": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all hostgroups.",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hostgroups/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a hostgroup.",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hostgroups/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an hostgroup.",
+                                "http_method": "POST",
+                                "api_url": "/api/hostgroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "hostgroup",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "hostgroup[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "parent_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[parent_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[environment_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[medium_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[ptable_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[domain_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "hostgroup",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hostgroups/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an hostgroup.",
+                                "http_method": "PUT",
+                                "api_url": "/api/hostgroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "hostgroup",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "hostgroup[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "parent_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[parent_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[environment_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[medium_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[ptable_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[domain_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "hostgroup",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hostgroups/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an hostgroup.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hostgroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hostgroups/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/hostgroups",
+                "name": "Hostgroups"
+            },
+            "environments": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "import_puppetclasses",
+                        "apis": [
+                            {
+                                "short_description": "Import puppet classes from puppet proxy.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_proxy_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "smart_proxy_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "environment_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "environment_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "dryrun",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be 'true' or 'false'",
+                                "full_name": "dryrun",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "except",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "except",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Optional comma-deliminated string containing either 'new,updated,obsolete'\nused to limit the import_puppetclasses actions</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/import_puppetclasses",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all environments.",
+                                "http_method": "GET",
+                                "api_url": "/api/environments"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an environment.",
+                                "http_method": "GET",
+                                "api_url": "/api/environments/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/environments"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "environment",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "environment[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "environment",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an environment.",
+                                "http_method": "PUT",
+                                "api_url": "/api/environments/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "environment",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "environment[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "environment",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an environment.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/environments/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/environments/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/environments",
+                "name": "Environments"
+            },
+            "ptables": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all ptables.",
+                                "http_method": "GET",
+                                "api_url": "/api/ptables"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/ptables/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a ptable.",
+                                "http_method": "GET",
+                                "api_url": "/api/ptables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/ptables/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a ptable.",
+                                "http_method": "POST",
+                                "api_url": "/api/ptables"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "ptable",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "layout",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[layout]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[os_family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "ptable",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/ptables/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a ptable.",
+                                "http_method": "PUT",
+                                "api_url": "/api/ptables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "ptable",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "layout",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[layout]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[os_family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "ptable",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/ptables/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a ptable.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/ptables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/ptables/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/ptables",
+                "name": "Ptables"
+            },
+            "compute_resources": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all compute resources.",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/compute_resources/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an compute resource.",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/compute_resources/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a compute resource.",
+                                "http_method": "POST",
+                                "api_url": "/api/compute_resources"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provider",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[provider]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Providers include Libvirt, Ovirt, EC2, Openstack, Rackspace</p>\n"
+                                    },
+                                    {
+                                        "name": "url",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[url]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>URL for Libvirt, Ovirt, and Openstack</p>\n"
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "user",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[user]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2.</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2</p>\n"
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[uuid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Ovirt, Vmware Datacenter</p>\n"
+                                    },
+                                    {
+                                        "name": "region",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[region]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for EC2 only</p>\n"
+                                    },
+                                    {
+                                        "name": "tenant",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[tenant]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Openstack only</p>\n"
+                                    },
+                                    {
+                                        "name": "server",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[server]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Vmware</p>\n"
+                                    }
+                                ],
+                                "full_name": "compute_resource",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/compute_resources/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a compute resource.",
+                                "http_method": "PUT",
+                                "api_url": "/api/compute_resources/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "compute_resource",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provider",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[provider]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Providers include Libvirt, Ovirt, EC2, Openstack, Rackspace</p>\n"
+                                    },
+                                    {
+                                        "name": "url",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[url]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>URL for Libvirt, Ovirt, and Openstack</p>\n"
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "user",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[user]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2.</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2</p>\n"
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[uuid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Ovirt, Vmware Datacenter</p>\n"
+                                    },
+                                    {
+                                        "name": "region",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[region]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for EC2 only</p>\n"
+                                    },
+                                    {
+                                        "name": "tenant",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[tenant]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Openstack only</p>\n"
+                                    },
+                                    {
+                                        "name": "server",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[server]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Vmware</p>\n"
+                                    }
+                                ],
+                                "full_name": "compute_resource",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/compute_resources/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a compute resource.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/compute_resources/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/compute_resources/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/compute_resources",
+                "name": "Compute resources"
+            },
+            "common_parameters": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all common parameters.",
+                                "http_method": "GET",
+                                "api_url": "/api/common_parameters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/common_parameters/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a common parameter.",
+                                "http_method": "GET",
+                                "api_url": "/api/common_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/common_parameters/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a common_parameter",
+                                "http_method": "POST",
+                                "api_url": "/api/common_parameters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "common_parameter",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "value",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "common_parameter",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/common_parameters/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a common_parameter",
+                                "http_method": "PUT",
+                                "api_url": "/api/common_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "common_parameter",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "common_parameter",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/common_parameters/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a common_parameter",
+                                "http_method": "DELETE",
+                                "api_url": "/api/common_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/common_parameters/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/common_parameters",
+                "name": "Common parameters"
+            },
+            "images": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all images for compute resource",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            },
+                            {
+                                "name": "compute_resource_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/images/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an image",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "compute_resource_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/images/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a image",
+                                "http_method": "POST",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "image",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "username",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[username]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[uuid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "image",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/images/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a image.",
+                                "http_method": "PUT",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "image",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "username",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[username]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[uuid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "image",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/images/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an image.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/images/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/images",
+                "name": "Images"
+            },
+            "home": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "Show available links.",
+                                "http_method": "GET",
+                                "api_url": "/api"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/home/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "status",
+                        "apis": [
+                            {
+                                "short_description": "Show status.",
+                                "http_method": "GET",
+                                "api_url": "/api/status"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/home/status",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/home",
+                "name": "Home"
+            },
+            "audits": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all audits.",
+                                "http_method": "GET",
+                                "api_url": "/api/audits"
+                            },
+                            {
+                                "short_description": "List all audits for a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/audits"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/audits/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an audit",
+                                "http_method": "GET",
+                                "api_url": "/api/audits/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/audits/show",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/audits",
+                "name": "Audits"
+            },
+            "bookmarks": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all bookmarks.",
+                                "http_method": "GET",
+                                "api_url": "/api/bookmarks"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/bookmarks/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a bookmark.",
+                                "http_method": "GET",
+                                "api_url": "/api/bookmarks/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/bookmarks/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a bookmark.",
+                                "http_method": "POST",
+                                "api_url": "/api/bookmarks"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "bookmark",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "controller",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[controller]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "query",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[query]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "public",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "bookmark[public]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "bookmark",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/bookmarks/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a bookmark.",
+                                "http_method": "PUT",
+                                "api_url": "/api/bookmarks/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "bookmark",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "controller",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[controller]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "query",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[query]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "public",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "bookmark[public]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "bookmark",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/bookmarks/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a bookmark.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/bookmarks/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/bookmarks/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/bookmarks",
+                "name": "Bookmarks"
+            },
+            "auth_source_ldaps": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all authsource ldaps",
+                                "http_method": "GET",
+                                "api_url": "/api/auth_source_ldaps"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/auth_source_ldaps/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an authsource ldap.",
+                                "http_method": "GET",
+                                "api_url": "/api/auth_source_ldaps/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/auth_source_ldaps/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an auth_source_ldap.",
+                                "http_method": "POST",
+                                "api_url": "/api/auth_source_ldaps"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "auth_source_ldap",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[host]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "port",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "auth_source_ldap[port]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>defaults to 389</p>\n"
+                                    },
+                                    {
+                                        "name": "account",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "base_dn",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[base_dn]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "account_password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account_password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_login",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_login]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_firstname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_firstname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_lastname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_lastname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_mail",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_mail]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_photo",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_photo]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "onthefly_register",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[onthefly_register]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "tls",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[tls]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "auth_source_ldap",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/auth_source_ldaps/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an auth_source_ldap.",
+                                "http_method": "PUT",
+                                "api_url": "/api/auth_source_ldaps/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "auth_source_ldap",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[host]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "port",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "auth_source_ldap[port]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>defaults to 389</p>\n"
+                                    },
+                                    {
+                                        "name": "account",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "base_dn",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[base_dn]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "account_password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account_password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_login",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_login]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_firstname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_firstname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_lastname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_lastname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_mail",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_mail]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_photo",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_photo]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "onthefly_register",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[onthefly_register]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "tls",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[tls]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "auth_source_ldap",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/auth_source_ldaps/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an auth_source_ldap.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/auth_source_ldaps/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/auth_source_ldaps/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/auth_source_ldaps",
+                "name": "Auth source ldaps"
+            },
+            "statistics": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "Get statistics",
+                                "http_method": "GET",
+                                "api_url": "/api/statistics"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/statistics/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/statistics",
+                "name": "Statistics"
+            },
+            "media": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all media.",
+                                "http_method": "GET",
+                                "api_url": "/api/media"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>for example, name ASC, or name DESC</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/media/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a medium.",
+                                "http_method": "GET",
+                                "api_url": "/api/media/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/media/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a medium.",
+                                "http_method": "POST",
+                                "api_url": "/api/media"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "medium",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Name of media</p>\n"
+                                    },
+                                    {
+                                        "name": "path",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[path]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The path to the medium, can be a URL or a valid NFS server (exclusive of\nthe architecture).</p>\n\n<p>for example <a\nhref=\"http://mirror.centos.org/centos/$version/os/$arch\">mirror.centos.org/centos/$version/os/$arch</a>\nwhere $arch will be substituted for the host's actual OS architecture and\n$version, $major and $minor will be substituted for the version of the\noperating system.</p>\n\n<p>Solaris and Debian media may also use $release.</p>\n"
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[os_family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The family that the operating system belongs to.</p>\n\n<p>Available families:</p>\n<ul><li>\n<p>AIX</p>\n</li><li>\n<p>Archlinux</p>\n</li><li>\n<p>Debian</p>\n</li><li>\n<p>Freebsd</p>\n</li><li>\n<p>Gentoo</p>\n</li><li>\n<p>Junos</p>\n</li><li>\n<p>Redhat</p>\n</li><li>\n<p>Solaris</p>\n</li><li>\n<p>Suse</p>\n</li><li>\n<p>Windows</p>\n</li></ul>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "medium[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "medium",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/media/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a medium.",
+                                "http_method": "PUT",
+                                "api_url": "/api/media/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "medium",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Name of media</p>\n"
+                                    },
+                                    {
+                                        "name": "path",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[path]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The path to the medium, can be a URL or a valid NFS server (exclusive of\nthe architecture).</p>\n\n<p>for example <a\nhref=\"http://mirror.centos.org/centos/$version/os/$arch\">mirror.centos.org/centos/$version/os/$arch</a>\nwhere $arch will be substituted for the host's actual OS architecture and\n$version, $major and $minor will be substituted for the version of the\noperating system.</p>\n\n<p>Solaris and Debian media may also use $release.</p>\n"
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[os_family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The family that the operating system belongs to.</p>\n\n<p>Available families:</p>\n<ul><li>\n<p>AIX</p>\n</li><li>\n<p>Archlinux</p>\n</li><li>\n<p>Debian</p>\n</li><li>\n<p>Freebsd</p>\n</li><li>\n<p>Gentoo</p>\n</li><li>\n<p>Junos</p>\n</li><li>\n<p>Redhat</p>\n</li><li>\n<p>Solaris</p>\n</li><li>\n<p>Suse</p>\n</li><li>\n<p>Windows</p>\n</li></ul>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "medium[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "medium",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/media/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a medium.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/media/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/media/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/media",
+                "name": "Media"
+            },
+            "autosign": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all autosign",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_proxies/smart_proxy_id/autosign"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/autosign/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/autosign",
+                "name": "Autosign"
+            },
+            "fact_values": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all fact values.",
+                                "http_method": "GET",
+                                "api_url": "/api/fact_values"
+                            },
+                            {
+                                "short_description": "List all fact values of a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/facts"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/fact_values/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/fact_values",
+                "name": "Fact values"
+            },
+            "subnets": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List of subnets",
+                                "http_method": "GET",
+                                "api_url": "/api/subnets"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/subnets/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a subnet.",
+                                "http_method": "GET",
+                                "api_url": "/api/subnets/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/subnets/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a subnet",
+                                "http_method": "POST",
+                                "api_url": "/api/subnets"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "subnet",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Subnet name</p>\n"
+                                    },
+                                    {
+                                        "name": "network",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[network]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Subnet network</p>\n"
+                                    },
+                                    {
+                                        "name": "mask",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[mask]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Netmask for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "gateway",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[gateway]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_primary",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_primary]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_secondary",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_secondary]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Secondary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "from",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[from]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Starting IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "to",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[to]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Ending IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "vlanid",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[vlanid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>VLAN ID for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "subnet[domain_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Domains in which this subnet is part</p>\n"
+                                    },
+                                    {
+                                        "name": "dhcp_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dhcp_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DHCP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "tftp_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[tftp_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>TFTP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dns_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DNS Proxy to use within this subnet</p>\n"
+                                    }
+                                ],
+                                "full_name": "subnet",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/subnets/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a subnet",
+                                "http_method": "PUT",
+                                "api_url": "/api/subnets/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a number.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Subnet numeric identifier</p>\n"
+                            },
+                            {
+                                "name": "subnet",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Subnet name</p>\n"
+                                    },
+                                    {
+                                        "name": "network",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[network]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Subnet network</p>\n"
+                                    },
+                                    {
+                                        "name": "mask",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[mask]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Netmask for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "gateway",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[gateway]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_primary",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_primary]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_secondary",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_secondary]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Secondary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "from",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[from]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Starting IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "to",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[to]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Ending IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "vlanid",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[vlanid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>VLAN ID for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "subnet[domain_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Domains in which this subnet is part</p>\n"
+                                    },
+                                    {
+                                        "name": "dhcp_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dhcp_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DHCP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "tftp_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[tftp_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>TFTP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dns_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DNS Proxy to use within this subnet</p>\n"
+                                    }
+                                ],
+                                "full_name": "subnet",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/subnets/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a subnet",
+                                "http_method": "DELETE",
+                                "api_url": "/api/subnets/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a number.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Subnet numeric identifier</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/subnets/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/subnets",
+                "name": "Subnets"
+            },
+            "users": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all users.",
+                                "http_method": "GET",
+                                "api_url": "/api/users"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/users/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an user.",
+                                "http_method": "GET",
+                                "api_url": "/api/users/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/users/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an user.",
+                                "http_method": "POST",
+                                "api_url": "/api/users"
+                            }
+                        ],
+                        "full_description": "\n<p>Adds role 'Anonymous' to the user by default</p>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "user",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "login",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[login]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "firstname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[firstname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "lastname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[lastname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "mail",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[mail]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "admin",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "user[admin]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Is an admin account?</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "auth_source_id",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be Integer",
+                                        "full_name": "user[auth_source_id]",
+                                        "expected_type": "numeric",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "user",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/users/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an user.",
+                                "http_method": "PUT",
+                                "api_url": "/api/users/:id"
+                            }
+                        ],
+                        "full_description": "\n<p>Adds role 'Anonymous' to the user if it is not already present. Only admin\ncan set admin account.</p>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "user",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "login",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[login]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "firstname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "user[firstname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "lastname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "user[lastname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "mail",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[mail]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "admin",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "user[admin]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Is an admin account?</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "user",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/users/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an user.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/users/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/users/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/users",
+                "name": "Users"
+            },
+            "models": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all models.",
+                                "http_method": "GET",
+                                "api_url": "/api/models"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/models/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a model.",
+                                "http_method": "GET",
+                                "api_url": "/api/models/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/models/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a model.",
+                                "http_method": "POST",
+                                "api_url": "/api/models"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "model",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "info",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[info]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "vendor_class",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[vendor_class]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hardware_model",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[hardware_model]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "model",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/models/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a model.",
+                                "http_method": "PUT",
+                                "api_url": "/api/models/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "model",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "info",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[info]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "vendor_class",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[vendor_class]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hardware_model",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[hardware_model]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "model",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/models/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a model.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/models/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/models/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/models",
+                "name": "Models"
+            },
+            "config_templates": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List templates",
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show template details",
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a template",
+                                "http_method": "POST",
+                                "api_url": "/api/config_templates"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "config_template",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>template name</p>\n"
+                                    },
+                                    {
+                                        "name": "template",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[template]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "snippet",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "config_template[snippet]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "audit_comment",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[audit_comment]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "template_kind_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "config_template[template_kind_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not relevant for snippet</p>\n"
+                                    },
+                                    {
+                                        "name": "template_combinations_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[template_combinations_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of template combinations (hostgroup_id, environment_id)</p>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of operating systems ID to associate the template with</p>\n"
+                                    }
+                                ],
+                                "full_name": "config_template",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a template",
+                                "http_method": "PUT",
+                                "api_url": "/api/config_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "config_template",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>template name</p>\n"
+                                    },
+                                    {
+                                        "name": "template",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[template]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "snippet",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "config_template[snippet]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "audit_comment",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[audit_comment]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "template_kind_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "config_template[template_kind_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not relevant for snippet</p>\n"
+                                    },
+                                    {
+                                        "name": "template_combinations_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[template_combinations_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of template combinations (hostgroup_id, environment_id)</p>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of operating systems ID to associate the template with</p>\n"
+                                    }
+                                ],
+                                "full_name": "config_template",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "revision",
+                        "apis": [
+                            {
+                                "short_description": null,
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates/revision"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "version",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "version",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>template version</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/revision",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a template",
+                                "http_method": "DELETE",
+                                "api_url": "/api/config_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "build_pxe_default",
+                        "apis": [
+                            {
+                                "short_description": "Change the default PXE menu on all configured TFTP servers",
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates/build_pxe_default"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/config_templates/build_pxe_default",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/config_templates",
+                "name": "Config templates"
+            },
+            "usergroups": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all usergroups.",
+                                "http_method": "GET",
+                                "api_url": "/api/usergroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            },
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/usergroups/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a usergroup.",
+                                "http_method": "GET",
+                                "api_url": "/api/usergroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/usergroups/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a usergroup.",
+                                "http_method": "POST",
+                                "api_url": "/api/usergroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "usergroup",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "usergroup[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "usergroup",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/usergroups/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a usergroup.",
+                                "http_method": "PUT",
+                                "api_url": "/api/usergroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "usergroup",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "usergroup[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "usergroup",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/usergroups/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a usergroup.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/usergroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/usergroups/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/usergroups",
+                "name": "Usergroups"
+            },
+            "operatingsystems": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": "",
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all operating systems.",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>for example, name ASC, or name DESC</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an OS.",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an OS.",
+                                "http_method": "POST",
+                                "api_url": "/api/operatingsystems"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "operatingsystem",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must match regular expression /\\A(\\S+)\\Z/.",
+                                        "full_name": "operatingsystem[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "major",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[major]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "minor",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[minor]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "release_name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[release_name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "operatingsystem",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an OS.",
+                                "http_method": "PUT",
+                                "api_url": "/api/operatingsystems/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "operatingsystem",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must match regular expression /\\A(\\S+)\\Z/.",
+                                        "full_name": "operatingsystem[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "major",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[major]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "minor",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[minor]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "release_name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[release_name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "operatingsystem",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an OS.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/operatingsystems/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "bootfiles",
+                        "apis": [
+                            {
+                                "short_description": "List boot files an OS.",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems/:id/bootfiles"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "medium",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "medium",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "architecture",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "architecture",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/operatingsystems/bootfiles",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/operatingsystems",
+                "name": "Operating systems"
+            },
+            "puppetclasses": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all puppetclasses.",
+                                "http_method": "GET",
+                                "api_url": "/api/puppetclasses"
+                            },
+                            {
+                                "short_description": "List all puppetclasses of a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/puppetclasses/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a puppetclass.",
+                                "http_method": "GET",
+                                "api_url": "/api/puppetclasses/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/puppetclasses/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a puppetclass.",
+                                "http_method": "POST",
+                                "api_url": "/api/puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "puppetclass",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "puppetclass[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "puppetclass",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/puppetclasses/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a puppetclass.",
+                                "http_method": "PUT",
+                                "api_url": "/api/puppetclasses/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "puppetclass",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "puppetclass[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "puppetclass",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/puppetclasses/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a puppetclass.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/puppetclasses/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/puppetclasses/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/puppetclasses",
+                "name": "Puppetclasses"
+            },
+            "roles": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all roles.",
+                                "http_method": "GET",
+                                "api_url": "/api/roles"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/roles/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an role.",
+                                "http_method": "GET",
+                                "api_url": "/api/roles/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/roles/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an role.",
+                                "http_method": "POST",
+                                "api_url": "/api/roles"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "role",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "role[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "role",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/roles/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an role.",
+                                "http_method": "PUT",
+                                "api_url": "/api/roles/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "role",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "role[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "role",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/roles/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an role.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/roles/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/roles/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/roles",
+                "name": "Roles"
+            },
+            "settings": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all settings.",
+                                "http_method": "GET",
+                                "api_url": "/api/settings"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/settings/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an setting.",
+                                "http_method": "GET",
+                                "api_url": "/api/settings/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/settings/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a setting.",
+                                "http_method": "PUT",
+                                "api_url": "/api/settings/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "setting",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "setting[value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "setting",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/settings/update",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/settings",
+                "name": "Settings"
+            },
+            "smart_proxies": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "import_puppetclasses",
+                        "apis": [
+                            {
+                                "short_description": "Import puppet classes from puppet proxy.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_proxy_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "smart_proxy_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "environment_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "environment_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "dryrun",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be 'true' or 'false'",
+                                "full_name": "dryrun",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "except",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "except",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Optional comma-deliminated string containing either 'new,updated,obsolete'\nused to limit the import_puppetclasses actions</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/import_puppetclasses",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all smart_proxies.",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_proxies"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "type",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "type",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter by type</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a smart proxy.",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_proxies/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a smart proxy.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "smart_proxy",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "url",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[url]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "smart_proxy",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a smart proxy.",
+                                "http_method": "PUT",
+                                "api_url": "/api/smart_proxies/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_proxy",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "url",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[url]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "smart_proxy",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a smart_proxy.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/smart_proxies/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "refresh",
+                        "apis": [
+                            {
+                                "short_description": "Refresh smart proxy features",
+                                "http_method": "PUT",
+                                "api_url": "/api/smart_proxies/:id/refresh"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/smart_proxies/refresh",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/smart_proxies",
+                "name": "Smart proxies"
+            },
+            "reports": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all reports.",
+                                "http_method": "GET",
+                                "api_url": "/api/reports"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/reports/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a report.",
+                                "http_method": "GET",
+                                "api_url": "/api/reports/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/reports/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a report.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/reports/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/reports/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "last",
+                        "apis": [
+                            {
+                                "short_description": "Show the last report for a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/reports/last"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/reports/last",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/reports",
+                "name": "Reports"
+            },
+            "hosts": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all hosts.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a host.",
+                                "http_method": "POST",
+                                "api_url": "/api/hosts"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[environment_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ip",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[ip]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not required if using a subnet with dhcp proxy</p>\n"
+                                    },
+                                    {
+                                        "name": "mac",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[mac]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not required if its a virtual machine</p>\n"
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[domain_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_class_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[puppet_class_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[medium_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[ptable_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "sp_subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[sp_subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "model_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[model_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hostgroup_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[hostgroup_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "owner_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[owner_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "image_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[image_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host_parameters_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[host_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "build",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[build]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "enabled",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[enabled]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provision_method",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[provision_method]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "managed",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[managed]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "progress_report_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[progress_report_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>UUID to track orchestration tasks status, GET\n/api/orchestration/:UUID/tasks</p>\n"
+                                    },
+                                    {
+                                        "name": "capabilities",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[capabilities]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a Hash",
+                                        "params": [],
+                                        "full_name": "host[compute_attributes]",
+                                        "expected_type": "hash",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "host",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a host.",
+                                "http_method": "PUT",
+                                "api_url": "/api/hosts/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "host",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[environment_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ip",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[ip]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not required if using a subnet with dhcp proxy</p>\n"
+                                    },
+                                    {
+                                        "name": "mac",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[mac]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not required if its a virtual machine</p>\n"
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[domain_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_class_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[puppet_class_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[medium_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[ptable_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "sp_subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[sp_subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "model_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[model_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hostgroup_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[hostgroup_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "owner_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[owner_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "image_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[image_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host_parameters_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[host_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "build",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[build]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "enabled",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[enabled]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provision_method",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[provision_method]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "managed",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[managed]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "progress_report_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[progress_report_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>UUID to track orchestration tasks status, GET\n/api/orchestration/:UUID/tasks</p>\n"
+                                    },
+                                    {
+                                        "name": "capabilities",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[capabilities]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a Hash",
+                                        "params": [],
+                                        "full_name": "host[compute_attributes]",
+                                        "expected_type": "hash",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "host",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an host.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hosts/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "status",
+                        "apis": [
+                            {
+                                "short_description": "Get status of host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:id/status"
+                            }
+                        ],
+                        "full_description": "\n<p>Return value may either be one of the following:</p>\n<ul><li>\n<p>missing</p>\n</li><li>\n<p>failed</p>\n</li><li>\n<p>pending</p>\n</li><li>\n<p>changed</p>\n</li><li>\n<p>unchanged</p>\n</li><li>\n<p>unreported</p>\n</li></ul>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/hosts/status",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/hosts",
+                "name": "Hosts"
+            },
+            "dashboard": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "Get Dashboard results",
+                                "http_method": "GET",
+                                "api_url": "/api/dashboard"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/dashboard/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/dashboard",
+                "name": "Dashboard"
+            },
+            "domains": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": "\n<p>Foreman considers a domain and a DNS zone as the same thing. That is, if\nyou are planning to manage a site where all the machines are or the form\n<em>hostname</em>.<strong>somewhere.com</strong> then the domain is\n<strong>somewhere.com</strong>. This allows Foreman to associate a puppet\nvariable with a domain/site and automatically append this variable to all\nexternal node requests made by machines at that site.</p>\n",
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List of domains",
+                                "http_method": "GET",
+                                "api_url": "/api/domains"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/domains/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a domain.",
+                                "http_method": "GET",
+                                "api_url": "/api/domains/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>May be numerical id or domain name</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/domains/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a domain.",
+                                "http_method": "POST",
+                                "api_url": "/api/domains"
+                            }
+                        ],
+                        "full_description": "\n<p>The <strong>fullname</strong> field is used for human readability in\nreports and other pages that refer to domains, and also available as an\nexternal node parameter</p>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "domain",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The full DNS Domain name</p>\n"
+                                    },
+                                    {
+                                        "name": "fullname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[fullname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Full name describing the domain</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "domain[dns_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DNS Proxy to use within this domain</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_parameters_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "domain[domain_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of parameters (name, value)</p>\n"
+                                    }
+                                ],
+                                "full_name": "domain",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/domains/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a domain.",
+                                "http_method": "PUT",
+                                "api_url": "/api/domains/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "domain",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The full DNS Domain name</p>\n"
+                                    },
+                                    {
+                                        "name": "fullname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[fullname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Full name describing the domain</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "domain[dns_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DNS Proxy to use within this domain</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_parameters_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "domain[domain_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of parameters (name, value)</p>\n"
+                                    }
+                                ],
+                                "full_name": "domain",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/domains/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a domain.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/domains/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/domains/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/domains",
+                "name": "Domains"
+            },
+            "architectures": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v1",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all architectures.",
+                                "http_method": "GET",
+                                "api_url": "/api/architectures"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/architectures/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an architecture.",
+                                "http_method": "GET",
+                                "api_url": "/api/architectures/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/architectures/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an architecture.",
+                                "http_method": "POST",
+                                "api_url": "/api/architectures"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "architecture",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "architecture[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "architecture[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Operatingsystem ID's</p>\n"
+                                    }
+                                ],
+                                "full_name": "architecture",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/architectures/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an architecture.",
+                                "http_method": "PUT",
+                                "api_url": "/api/architectures/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "architecture",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "architecture[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Array",
+                                        "full_name": "architecture[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Operatingsystem ID's</p>\n"
+                                    }
+                                ],
+                                "full_name": "architecture",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/architectures/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an architecture.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/architectures/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v1/architectures/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v1/architectures",
+                "name": "Architectures"
+            }
+        },
+        "api_url": "/api"
+    }
+}

--- a/foreman/definitions/1.5.0-v2.json
+++ b/foreman/definitions/1.5.0-v2.json
@@ -1,0 +1,13143 @@
+{
+    "docs": {
+        "info": "\n<p>Foreman v2 is currently in development and is not the default version. You\nmay use v2 by either passing 'version=2' in the Accept Header or entering\napi/v2/ in the URL.</p>\n",
+        "name": "Foreman",
+        "copyright": "",
+        "doc_url": "/apidoc/v2",
+        "resources": {
+            "tasks": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all tasks for a given orchestration event",
+                                "http_method": "GET",
+                                "api_url": "/api/orchestration/:id/tasks"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/tasks/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/tasks",
+                "name": "Tasks"
+            },
+            "template_kinds": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all template kinds.",
+                                "http_method": "GET",
+                                "api_url": "/api/template_kinds"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/template_kinds/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/template_kinds",
+                "name": "Template kinds"
+            },
+            "plugins": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List of installed plugins",
+                                "http_method": "GET",
+                                "api_url": "/api/plugins"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/plugins/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/plugins",
+                "name": "Plugins"
+            },
+            "hostgroups": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all hostgroups.",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hostgroups/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a hostgroup.",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hostgroups/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an hostgroup.",
+                                "http_method": "POST",
+                                "api_url": "/api/hostgroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "hostgroup",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "hostgroup[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "parent_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[parent_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[environment_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[medium_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[ptable_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[domain_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "realm_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[realm_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "hostgroup",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hostgroups/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an hostgroup.",
+                                "http_method": "PUT",
+                                "api_url": "/api/hostgroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "hostgroup",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "hostgroup[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "parent_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[parent_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[environment_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[medium_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[ptable_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[domain_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "realm_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[realm_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "hostgroup[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "hostgroup",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hostgroups/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an hostgroup.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hostgroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hostgroups/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/hostgroups",
+                "name": "Hostgroups"
+            },
+            "locations": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all locations",
+                                "http_method": "GET",
+                                "api_url": "/api/locations"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/locations/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a location",
+                                "http_method": "GET",
+                                "api_url": "/api/locations/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/locations/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a location",
+                                "http_method": "POST",
+                                "api_url": "/api/locations"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "location",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "location[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "location",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/locations/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a location",
+                                "http_method": "PUT",
+                                "api_url": "/api/locations/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "location",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "location[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "location",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/locations/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a location",
+                                "http_method": "DELETE",
+                                "api_url": "/api/locations/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/locations/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/locations",
+                "name": "Locations"
+            },
+            "environments": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "import_puppetclasses",
+                        "apis": [
+                            {
+                                "short_description": "Import puppet classes from puppet proxy.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_proxy_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "smart_proxy_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "environment_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "environment_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "dryrun",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be 'true' or 'false'",
+                                "full_name": "dryrun",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "except",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "except",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Optional comma-deliminated string containing either 'new,updated,obsolete'\nused to limit the import_puppetclasses actions</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/environments/import_puppetclasses",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all environments.",
+                                "http_method": "GET",
+                                "api_url": "/api/environments"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/environments/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an environment.",
+                                "http_method": "GET",
+                                "api_url": "/api/environments/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/environments/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/environments"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "environment",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "environment[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "environment",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/environments/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an environment.",
+                                "http_method": "PUT",
+                                "api_url": "/api/environments/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "environment",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "environment[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "environment",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/environments/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an environment.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/environments/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/environments/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/environments",
+                "name": "Environments"
+            },
+            "ptables": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all ptables.",
+                                "http_method": "GET",
+                                "api_url": "/api/ptables"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/ptables/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a ptable.",
+                                "http_method": "GET",
+                                "api_url": "/api/ptables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/ptables/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a ptable.",
+                                "http_method": "POST",
+                                "api_url": "/api/ptables"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "ptable",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "layout",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[layout]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[os_family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "ptable",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/ptables/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a ptable.",
+                                "http_method": "PUT",
+                                "api_url": "/api/ptables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "ptable",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "layout",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[layout]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "ptable[os_family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "ptable",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/ptables/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a ptable.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/ptables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/ptables/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/ptables",
+                "name": "Ptables"
+            },
+            "compute_resources": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all compute resources.",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/compute_resources/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an compute resource.",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/compute_resources/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a compute resource.",
+                                "http_method": "POST",
+                                "api_url": "/api/compute_resources"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provider",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[provider]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Providers include Libvirt, Ovirt, EC2, Openstack, Rackspace</p>\n"
+                                    },
+                                    {
+                                        "name": "url",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[url]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>URL for Libvirt, Ovirt, and Openstack</p>\n"
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "user",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[user]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2.</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2</p>\n"
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[uuid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Ovirt, Vmware Datacenter</p>\n"
+                                    },
+                                    {
+                                        "name": "region",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[region]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for EC2 only</p>\n"
+                                    },
+                                    {
+                                        "name": "tenant",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[tenant]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Openstack only</p>\n"
+                                    },
+                                    {
+                                        "name": "server",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[server]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Vmware</p>\n"
+                                    }
+                                ],
+                                "full_name": "compute_resource",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/compute_resources/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a compute resource.",
+                                "http_method": "PUT",
+                                "api_url": "/api/compute_resources/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "compute_resource",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provider",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[provider]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Providers include Libvirt, Ovirt, EC2, Openstack, Rackspace</p>\n"
+                                    },
+                                    {
+                                        "name": "url",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[url]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>URL for Libvirt, Ovirt, and Openstack</p>\n"
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "user",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[user]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2.</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2</p>\n"
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[uuid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Ovirt, Vmware Datacenter</p>\n"
+                                    },
+                                    {
+                                        "name": "region",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[region]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for EC2 only</p>\n"
+                                    },
+                                    {
+                                        "name": "tenant",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[tenant]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Openstack only</p>\n"
+                                    },
+                                    {
+                                        "name": "server",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "compute_resource[server]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>for Vmware</p>\n"
+                                    }
+                                ],
+                                "full_name": "compute_resource",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/compute_resources/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a compute resource.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/compute_resources/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/compute_resources/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "available_images",
+                        "apis": [
+                            {
+                                "short_description": "List available images for a compute resource.",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:id/available_images"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/compute_resources/available_images",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "available_clusters",
+                        "apis": [
+                            {
+                                "short_description": "List available clusters for a compute resource",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:id/available_clusters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/compute_resources/available_clusters",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "available_networks",
+                        "apis": [
+                            {
+                                "short_description": "List available networks for a compute resource",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:id/available_networks"
+                            },
+                            {
+                                "short_description": "List available networks for a compute resource cluster",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:id/available_clusters/:cluster_id/available_networks"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "cluster_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "cluster_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/compute_resources/available_networks",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "available_storage_domains",
+                        "apis": [
+                            {
+                                "short_description": "List storage_domains for a compute resource",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:id/available_storage_domains"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/compute_resources/available_storage_domains",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/compute_resources",
+                "name": "Compute resources"
+            },
+            "filters": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all filters.",
+                                "http_method": "GET",
+                                "api_url": "/api/filters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/filters/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a filter.",
+                                "http_method": "GET",
+                                "api_url": "/api/filters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/filters/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a filter.",
+                                "http_method": "POST",
+                                "api_url": "/api/filters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "filter",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "role_id",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "filter[role_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "search",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "filter[search]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "permission_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "filter[permission_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "organization_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "filter[organization_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "location_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "filter[location_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "filter",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/filters/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a filter.",
+                                "http_method": "PUT",
+                                "api_url": "/api/filters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "filter",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "role_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "filter[role_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "search",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "filter[search]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "permission_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "filter[permission_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "organization_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "filter[organization_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "location_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "filter[location_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "filter",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/filters/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a filter.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/filters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/filters/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/filters",
+                "name": "Filters"
+            },
+            "common_parameters": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all common parameters.",
+                                "http_method": "GET",
+                                "api_url": "/api/common_parameters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/common_parameters/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a common parameter.",
+                                "http_method": "GET",
+                                "api_url": "/api/common_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/common_parameters/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a common_parameter",
+                                "http_method": "POST",
+                                "api_url": "/api/common_parameters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "common_parameter",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "value",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "common_parameter",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/common_parameters/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a common_parameter",
+                                "http_method": "PUT",
+                                "api_url": "/api/common_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "common_parameter",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "common_parameter[value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "common_parameter",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/common_parameters/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a common_parameter",
+                                "http_method": "DELETE",
+                                "api_url": "/api/common_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/common_parameters/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/common_parameters",
+                "name": "Common parameters"
+            },
+            "images": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all images for compute resource",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            },
+                            {
+                                "name": "compute_resource_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/images/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an image",
+                                "http_method": "GET",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "compute_resource_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/images/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a image",
+                                "http_method": "POST",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "image",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "username",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[username]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[uuid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "image",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/images/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a image.",
+                                "http_method": "PUT",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "image",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "username",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[username]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "uuid",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "image[uuid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be a number.",
+                                        "full_name": "image[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "image",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/images/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an image.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/compute_resources/:compute_resource_id/images/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "compute_resource_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "compute_resource_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/images/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/images",
+                "name": "Images"
+            },
+            "home": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "Show available links.",
+                                "http_method": "GET",
+                                "api_url": "/api"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/home/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "status",
+                        "apis": [
+                            {
+                                "short_description": "Show status.",
+                                "http_method": "GET",
+                                "api_url": "/api/status"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/home/status",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/home",
+                "name": "Home"
+            },
+            "audits": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all audits.",
+                                "http_method": "GET",
+                                "api_url": "/api/audits"
+                            },
+                            {
+                                "short_description": "List all audits for a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/audits"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/audits/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an audit",
+                                "http_method": "GET",
+                                "api_url": "/api/audits/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/audits/show",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/audits",
+                "name": "Audits"
+            },
+            "smart_class_parameters": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all smart class parameters",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_class_parameters"
+                            },
+                            {
+                                "short_description": "List of smart class parameters for a specific host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/smart_class_parameters"
+                            },
+                            {
+                                "short_description": "List of smart class parameters for a specific hostgroup",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups/:hostgroup_id/smart_class_parameters"
+                            },
+                            {
+                                "short_description": "List of smart class parameters for a specific puppetclass",
+                                "http_method": "GET",
+                                "api_url": "/api/puppetclasses/:puppetclass_id/smart_class_parameters"
+                            },
+                            {
+                                "short_description": "List of smart class parameters for a specific environment",
+                                "http_method": "GET",
+                                "api_url": "/api/environments/:environment_id/smart_class_parameters"
+                            },
+                            {
+                                "short_description": "List of smart class parameters for a specific environment/puppetclass combination",
+                                "http_method": "GET",
+                                "api_url": "/api/environments/:environment_id/puppetclasses/:puppetclass_id/smart_class_parameters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "puppetclass_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "puppetclass_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "environment_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "environment_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_class_parameters/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a smart class parameter.",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_class_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_class_parameters/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a smart class parameter.",
+                                "http_method": "PUT",
+                                "api_url": "/api/smart_class_parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_class_parameter",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "override",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "smart_class_parameter[override]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_class_parameter[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "default_value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_class_parameter[default_value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "path",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_class_parameter[path]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "validator_type",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_class_parameter[validator_type]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "validator_rule",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_class_parameter[validator_rule]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "override_value_order",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_class_parameter[override_value_order]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "parameter_type",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_class_parameter[parameter_type]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "required",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "smart_class_parameter[required]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "smart_class_parameter",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_class_parameters/update",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/smart_class_parameters",
+                "name": "Smart class parameters"
+            },
+            "bookmarks": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all bookmarks.",
+                                "http_method": "GET",
+                                "api_url": "/api/bookmarks"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/bookmarks/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a bookmark.",
+                                "http_method": "GET",
+                                "api_url": "/api/bookmarks/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/bookmarks/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a bookmark.",
+                                "http_method": "POST",
+                                "api_url": "/api/bookmarks"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "bookmark",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "controller",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[controller]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "query",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[query]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "public",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "bookmark[public]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "bookmark",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/bookmarks/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a bookmark.",
+                                "http_method": "PUT",
+                                "api_url": "/api/bookmarks/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "bookmark",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "controller",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[controller]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "query",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "bookmark[query]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "public",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "bookmark[public]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "bookmark",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/bookmarks/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a bookmark.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/bookmarks/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/bookmarks/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/bookmarks",
+                "name": "Bookmarks"
+            },
+            "override_values": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List of override values for a specific smart_variable",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_variables/:smart_variable_id/override_values"
+                            },
+                            {
+                                "short_description": "List of override values for a specific smart class parameter",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_class_parameters/:smart_class_parameter_id/override_values"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "smart_variable_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "smart_variable_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_class_parameter_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "smart_class_parameter_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/override_values/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an override value for a specific smart_variable",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_variables/:smart_variable_id/override_values/:id"
+                            },
+                            {
+                                "short_description": "Show an override value for a specific smart class parameter",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "smart_variable_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "smart_variable_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_class_parameter_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "smart_class_parameter_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/override_values/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an override value for a specific smart_variable",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_variables/:smart_variable_id/override_values"
+                            },
+                            {
+                                "short_description": "Create an override value for a specific smart class parameter",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_class_parameters/:smart_class_parameter_id/override_values"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "smart_variable_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "smart_variable_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "override_value",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "match",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "override_value[match]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "override_value[value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "override_value",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/override_values/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an override value for a specific smart_variable",
+                                "http_method": "PUT",
+                                "api_url": "/api/smart_variables/:smart_variable_id/override_values/:id"
+                            },
+                            {
+                                "short_description": "Update an override value for a specific smart class parameter",
+                                "http_method": "PUT",
+                                "api_url": "/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "override_value",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "match",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "override_value[match]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "override_value[value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "override_value",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/override_values/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an override value for a specific smart_variable",
+                                "http_method": "DELETE",
+                                "api_url": "/api/smart_variables/:smart_variable_id/override_values/:id"
+                            },
+                            {
+                                "short_description": "Delete an override value for a specific smart class parameter",
+                                "http_method": "DELETE",
+                                "api_url": "/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/override_values/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/override_values",
+                "name": "Override values"
+            },
+            "auth_source_ldaps": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all authsource ldaps",
+                                "http_method": "GET",
+                                "api_url": "/api/auth_source_ldaps"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/auth_source_ldaps/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an authsource ldap.",
+                                "http_method": "GET",
+                                "api_url": "/api/auth_source_ldaps/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/auth_source_ldaps/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an auth_source_ldap.",
+                                "http_method": "POST",
+                                "api_url": "/api/auth_source_ldaps"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "auth_source_ldap",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[host]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "port",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "auth_source_ldap[port]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>defaults to 389</p>\n"
+                                    },
+                                    {
+                                        "name": "account",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "base_dn",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[base_dn]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "account_password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account_password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_login",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_login]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_firstname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_firstname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_lastname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_lastname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_mail",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_mail]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_photo",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_photo]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "onthefly_register",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[onthefly_register]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "tls",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[tls]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "auth_source_ldap",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/auth_source_ldaps/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an auth_source_ldap.",
+                                "http_method": "PUT",
+                                "api_url": "/api/auth_source_ldaps/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "auth_source_ldap",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[host]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "port",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "auth_source_ldap[port]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>defaults to 389</p>\n"
+                                    },
+                                    {
+                                        "name": "account",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "base_dn",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[base_dn]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "account_password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[account_password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_login",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_login]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_firstname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_firstname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_lastname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_lastname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_mail",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_mail]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>required if onthefly_register is true</p>\n"
+                                    },
+                                    {
+                                        "name": "attr_photo",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "auth_source_ldap[attr_photo]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "onthefly_register",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[onthefly_register]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "tls",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "auth_source_ldap[tls]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "auth_source_ldap",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/auth_source_ldaps/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an auth_source_ldap.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/auth_source_ldaps/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/auth_source_ldaps/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/auth_source_ldaps",
+                "name": "Auth source ldaps"
+            },
+            "statistics": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "Get statistics",
+                                "http_method": "GET",
+                                "api_url": "/api/statistics"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/statistics/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/statistics",
+                "name": "Statistics"
+            },
+            "parameters": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": "\n<p>These API calls are related to <strong>nested parameters for host, domain,\nhostgroup, operating system</strong>. If you are looking for &lt;a\nhref=\"common_parameters.html\"&gt;global parameters&lt;/a&gt;, go to &lt;a\nhref=\"common_parameters.html\"&gt;this link&lt;/a&gt;.</p>\n",
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all parameters for host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/parameters"
+                            },
+                            {
+                                "short_description": "List all parameters for hostgroup",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters"
+                            },
+                            {
+                                "short_description": "List all parameters for domain",
+                                "http_method": "GET",
+                                "api_url": "/api/domains/:domain_id/parameters"
+                            },
+                            {
+                                "short_description": "List all parameters for operating system",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters"
+                            },
+                            {
+                                "short_description": "List all parameters for location",
+                                "http_method": "GET",
+                                "api_url": "/api/locations/:location_id/parameters"
+                            },
+                            {
+                                "short_description": "List all parameters for organization",
+                                "http_method": "GET",
+                                "api_url": "/api/organizations/:organization_id/parameters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of host</p>\n"
+                            },
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of hostgroup</p>\n"
+                            },
+                            {
+                                "name": "domain_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "domain_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of domain</p>\n"
+                            },
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "location_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "location_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of location</p>\n"
+                            },
+                            {
+                                "name": "organization_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "organization_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of organization</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/parameters/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a nested parameter for host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Show a nested parameter for hostgroup",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Show a nested parameter for domain",
+                                "http_method": "GET",
+                                "api_url": "/api/domains/:domain_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Show a nested parameter for operating system",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Show a nested parameter for location",
+                                "http_method": "GET",
+                                "api_url": "/api/locations/:location_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Show a nested parameter for organization",
+                                "http_method": "GET",
+                                "api_url": "/api/organizations/:organization_id/parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of host</p>\n"
+                            },
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of hostgroup</p>\n"
+                            },
+                            {
+                                "name": "domain_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "domain_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of domain</p>\n"
+                            },
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "location_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "location_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of location</p>\n"
+                            },
+                            {
+                                "name": "organization_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "organization_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of organization</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of parameter</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/parameters/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a nested parameter for host",
+                                "http_method": "POST",
+                                "api_url": "/api/hosts/:host_id/parameters"
+                            },
+                            {
+                                "short_description": "Create a nested parameter for hostgroup",
+                                "http_method": "POST",
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters"
+                            },
+                            {
+                                "short_description": "Create a nested parameter for domain",
+                                "http_method": "POST",
+                                "api_url": "/api/domains/:domain_id/parameters"
+                            },
+                            {
+                                "short_description": "Create a nested parameter for operating system",
+                                "http_method": "POST",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters"
+                            },
+                            {
+                                "short_description": "Create a nested parameter for location",
+                                "http_method": "POST",
+                                "api_url": "/api/locations/:location_id/parameters"
+                            },
+                            {
+                                "short_description": "Create a nested parameter for organization",
+                                "http_method": "POST",
+                                "api_url": "/api/organizations/:organization_id/parameters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of host</p>\n"
+                            },
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of hostgroup</p>\n"
+                            },
+                            {
+                                "name": "domain_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "domain_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of domain</p>\n"
+                            },
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "location_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "location_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of location</p>\n"
+                            },
+                            {
+                                "name": "organization_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "organization_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of organization</p>\n"
+                            },
+                            {
+                                "name": "parameter",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "parameter[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "value",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "parameter[value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "parameter",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/parameters/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a nested parameter for host",
+                                "http_method": "PUT",
+                                "api_url": "/api/hosts/:host_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Update a nested parameter for hostgroup",
+                                "http_method": "PUT",
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Update a nested parameter for domain",
+                                "http_method": "PUT",
+                                "api_url": "/api/domains/:domain_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Update a nested parameter for operating system",
+                                "http_method": "PUT",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Update a nested parameter for location",
+                                "http_method": "PUT",
+                                "api_url": "/api/locations/:location_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Update a nested parameter for organization",
+                                "http_method": "PUT",
+                                "api_url": "/api/organizations/:organization_id/parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of host</p>\n"
+                            },
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of hostgroup</p>\n"
+                            },
+                            {
+                                "name": "domain_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "domain_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of domain</p>\n"
+                            },
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "location_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "location_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of location</p>\n"
+                            },
+                            {
+                                "name": "organization_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "organization_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of organization</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of parameter</p>\n"
+                            },
+                            {
+                                "name": "parameter",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "parameter[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "parameter[value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "parameter",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/parameters/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a nested parameter for host",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hosts/:host_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Delete a nested parameter for hostgroup",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Delete a nested parameter for domain",
+                                "http_method": "DELETE",
+                                "api_url": "/api/domains/:domain_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Delete a nested parameter for operating system",
+                                "http_method": "DELETE",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Delete a nested parameter for location",
+                                "http_method": "DELETE",
+                                "api_url": "/api/locations/:location_id/parameters/:id"
+                            },
+                            {
+                                "short_description": "Delete a nested parameter for organization",
+                                "http_method": "DELETE",
+                                "api_url": "/api/organizations/:organization_id/parameters/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of host</p>\n"
+                            },
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of hostgroup</p>\n"
+                            },
+                            {
+                                "name": "domain_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "domain_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of domain</p>\n"
+                            },
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "location_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "location_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of location</p>\n"
+                            },
+                            {
+                                "name": "organization_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "organization_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of organization</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of parameter</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/parameters/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "reset",
+                        "apis": [
+                            {
+                                "short_description": "Delete all nested parameters for host",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hosts/:host_id/parameters"
+                            },
+                            {
+                                "short_description": "Delete all nested parameters for hostgroup",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hostgroups/:hostgroup_id/parameters"
+                            },
+                            {
+                                "short_description": "Delete all nested parameters for domain",
+                                "http_method": "DELETE",
+                                "api_url": "/api/domains/:domain_id/parameters"
+                            },
+                            {
+                                "short_description": "Delete all nested parameters for operating system",
+                                "http_method": "DELETE",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/parameters"
+                            },
+                            {
+                                "short_description": "Delete all nested parameter for location",
+                                "http_method": "DELETE",
+                                "api_url": "/api/locations/:location_id/parameters"
+                            },
+                            {
+                                "short_description": "Delete all nested parameter for organization",
+                                "http_method": "DELETE",
+                                "api_url": "/api/organizations/:organization_id/parameters"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of host</p>\n"
+                            },
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of hostgroup</p>\n"
+                            },
+                            {
+                                "name": "domain_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "domain_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of domain</p>\n"
+                            },
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "location_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "location_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of location</p>\n"
+                            },
+                            {
+                                "name": "organization_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "organization_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of organization</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/parameters/reset",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/parameters",
+                "name": "Parameters"
+            },
+            "media": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all media.",
+                                "http_method": "GET",
+                                "api_url": "/api/media"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>for example, name ASC, or name DESC</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/media/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a medium.",
+                                "http_method": "GET",
+                                "api_url": "/api/media/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/media/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a medium.",
+                                "http_method": "POST",
+                                "api_url": "/api/media"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "medium",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Name of media</p>\n"
+                                    },
+                                    {
+                                        "name": "path",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[path]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The path to the medium, can be a URL or a valid NFS server (exclusive of\nthe architecture).</p>\n\n<p>for example <a\nhref=\"http://mirror.centos.org/centos/$version/os/$arch\">mirror.centos.org/centos/$version/os/$arch</a>\nwhere $arch will be substituted for the host's actual OS architecture and\n$version, $major and $minor will be substituted for the version of the\noperating system.</p>\n\n<p>Solaris and Debian media may also use $release.</p>\n"
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[os_family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The family that the operating system belongs to.</p>\n\n<p>Available families:</p>\n<ul><li>\n<p>AIX</p>\n</li><li>\n<p>Archlinux</p>\n</li><li>\n<p>Debian</p>\n</li><li>\n<p>Freebsd</p>\n</li><li>\n<p>Gentoo</p>\n</li><li>\n<p>Junos</p>\n</li><li>\n<p>Redhat</p>\n</li><li>\n<p>Solaris</p>\n</li><li>\n<p>Suse</p>\n</li><li>\n<p>Windows</p>\n</li></ul>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "medium[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "medium",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/media/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a medium.",
+                                "http_method": "PUT",
+                                "api_url": "/api/media/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "medium",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Name of media</p>\n"
+                                    },
+                                    {
+                                        "name": "path",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[path]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The path to the medium, can be a URL or a valid NFS server (exclusive of\nthe architecture).</p>\n\n<p>for example <a\nhref=\"http://mirror.centos.org/centos/$version/os/$arch\">mirror.centos.org/centos/$version/os/$arch</a>\nwhere $arch will be substituted for the host's actual OS architecture and\n$version, $major and $minor will be substituted for the version of the\noperating system.</p>\n\n<p>Solaris and Debian media may also use $release.</p>\n"
+                                    },
+                                    {
+                                        "name": "os_family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "medium[os_family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The family that the operating system belongs to.</p>\n\n<p>Available families:</p>\n<ul><li>\n<p>AIX</p>\n</li><li>\n<p>Archlinux</p>\n</li><li>\n<p>Debian</p>\n</li><li>\n<p>Freebsd</p>\n</li><li>\n<p>Gentoo</p>\n</li><li>\n<p>Junos</p>\n</li><li>\n<p>Redhat</p>\n</li><li>\n<p>Solaris</p>\n</li><li>\n<p>Suse</p>\n</li><li>\n<p>Windows</p>\n</li></ul>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "medium[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "medium",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/media/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a medium.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/media/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/media/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/media",
+                "name": "Media"
+            },
+            "host_classes": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all puppetclass id's for host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/puppetclass_ids"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/host_classes/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Add a puppetclass to host",
+                                "http_method": "POST",
+                                "api_url": "/api/hosts/:host_id/puppetclass_ids"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of host</p>\n"
+                            },
+                            {
+                                "name": "puppetclass_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "puppetclass_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of puppetclass</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/host_classes/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Remove a puppetclass from host",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hosts/:host_id/puppetclass_ids/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of host</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of puppetclass</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/host_classes/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/host_classes",
+                "name": "Host classes"
+            },
+            "autosign": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all autosign",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_proxies/smart_proxy_id/autosign"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/autosign/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/autosign",
+                "name": "Autosign"
+            },
+            "models": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all models.",
+                                "http_method": "GET",
+                                "api_url": "/api/models"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/models/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a model.",
+                                "http_method": "GET",
+                                "api_url": "/api/models/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/models/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a model.",
+                                "http_method": "POST",
+                                "api_url": "/api/models"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "model",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "info",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "model[info]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "vendor_class",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "model[vendor_class]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hardware_model",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "model[hardware_model]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "model",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/models/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a model.",
+                                "http_method": "PUT",
+                                "api_url": "/api/models/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "model",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "model[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "info",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "model[info]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "vendor_class",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "model[vendor_class]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hardware_model",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "model[hardware_model]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "model",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/models/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a model.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/models/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/models/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/models",
+                "name": "Models"
+            },
+            "subnets": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List of subnets",
+                                "http_method": "GET",
+                                "api_url": "/api/subnets"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/subnets/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a subnet.",
+                                "http_method": "GET",
+                                "api_url": "/api/subnets/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/subnets/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a subnet",
+                                "http_method": "POST",
+                                "api_url": "/api/subnets"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "subnet",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Subnet name</p>\n"
+                                    },
+                                    {
+                                        "name": "network",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[network]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Subnet network</p>\n"
+                                    },
+                                    {
+                                        "name": "mask",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[mask]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Netmask for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "gateway",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[gateway]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_primary",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_primary]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_secondary",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_secondary]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Secondary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "from",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[from]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Starting IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "to",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[to]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Ending IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "vlanid",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[vlanid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>VLAN ID for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "subnet[domain_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Domains in which this subnet is part</p>\n"
+                                    },
+                                    {
+                                        "name": "dhcp_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dhcp_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DHCP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "tftp_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[tftp_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>TFTP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dns_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DNS Proxy to use within this subnet</p>\n"
+                                    }
+                                ],
+                                "full_name": "subnet",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/subnets/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a subnet",
+                                "http_method": "PUT",
+                                "api_url": "/api/subnets/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a number.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Subnet numeric identifier</p>\n"
+                            },
+                            {
+                                "name": "subnet",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Subnet name</p>\n"
+                                    },
+                                    {
+                                        "name": "network",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[network]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Subnet network</p>\n"
+                                    },
+                                    {
+                                        "name": "mask",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[mask]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Netmask for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "gateway",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[gateway]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_primary",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_primary]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Primary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_secondary",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[dns_secondary]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Secondary DNS for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "from",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[from]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Starting IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "to",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[to]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Ending IP Address for IP auto suggestion</p>\n"
+                                    },
+                                    {
+                                        "name": "vlanid",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "subnet[vlanid]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>VLAN ID for this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "subnet[domain_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Domains in which this subnet is part</p>\n"
+                                    },
+                                    {
+                                        "name": "dhcp_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dhcp_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DHCP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "tftp_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[tftp_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>TFTP Proxy to use within this subnet</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "subnet[dns_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DNS Proxy to use within this subnet</p>\n"
+                                    }
+                                ],
+                                "full_name": "subnet",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/subnets/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a subnet",
+                                "http_method": "DELETE",
+                                "api_url": "/api/subnets/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a number.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Subnet numeric identifier</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/subnets/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/subnets",
+                "name": "Subnets"
+            },
+            "hostgroup_classes": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all puppetclass id's for hostgroup",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups/:hostgroup_id/puppetclass_ids"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hostgroup_classes/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Add a puppetclass to hostgroup",
+                                "http_method": "POST",
+                                "api_url": "/api/hostgroups/:hostgroup_id/puppetclass_ids"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of hostgroup</p>\n"
+                            },
+                            {
+                                "name": "puppetclass_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "puppetclass_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of puppetclass</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hostgroup_classes/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Remove a puppetclass from hostgroup",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hostgroups/:hostgroup_id/puppetclass_ids/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of hostgroup</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of puppetclass</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hostgroup_classes/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/hostgroup_classes",
+                "name": "Hostgroup classes"
+            },
+            "config_groups": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List of config groups",
+                                "http_method": "GET",
+                                "api_url": "/api/config_groups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            },
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_groups/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a config group.",
+                                "http_method": "GET",
+                                "api_url": "/api/config_groups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_groups/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a config group.",
+                                "http_method": "POST",
+                                "api_url": "/api/config_groups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "config_group",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_group[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "config_group",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_groups/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a config group.",
+                                "http_method": "PUT",
+                                "api_url": "/api/config_groups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "config_group",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_group[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "config_group",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_groups/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a config group.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/config_groups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_groups/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/config_groups",
+                "name": "Config groups"
+            },
+            "users": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all users.",
+                                "http_method": "GET",
+                                "api_url": "/api/users"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/users/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an user.",
+                                "http_method": "GET",
+                                "api_url": "/api/users/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/users/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an user.",
+                                "http_method": "POST",
+                                "api_url": "/api/users"
+                            }
+                        ],
+                        "full_description": "\n<p>Adds role 'Anonymous' to the user by default</p>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "user",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "login",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[login]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "firstname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "user[firstname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "lastname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "user[lastname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "mail",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[mail]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "admin",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "user[admin]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Is an admin account?</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "auth_source_id",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be Integer",
+                                        "full_name": "user[auth_source_id]",
+                                        "expected_type": "numeric",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "user",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/users/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an user.",
+                                "http_method": "PUT",
+                                "api_url": "/api/users/:id"
+                            }
+                        ],
+                        "full_description": "\n<p>Adds role 'Anonymous' to the user if it is not already present. Only admin\ncan set admin account.</p>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "user",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "login",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[login]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "firstname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "user[firstname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "lastname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "user[lastname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "mail",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[mail]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "admin",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "user[admin]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Is an admin account?</p>\n"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "user[password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "auth_source_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be Integer",
+                                        "full_name": "user[auth_source_id]",
+                                        "expected_type": "numeric",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "user",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/users/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an user.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/users/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/users/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/users",
+                "name": "Users"
+            },
+            "fact_values": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all fact values.",
+                                "http_method": "GET",
+                                "api_url": "/api/fact_values"
+                            },
+                            {
+                                "short_description": "List all fact values of a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/facts"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/fact_values/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/fact_values",
+                "name": "Fact values"
+            },
+            "interfaces": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all interfaces for host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/interfaces"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id or name of host</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/interfaces/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an interface for host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/interfaces/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id or name of nested host</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id or name of interface</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/interfaces/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an interface linked to a host",
+                                "http_method": "POST",
+                                "api_url": "/api/hosts/:host_id/interfaces"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id or name of host</p>\n"
+                            },
+                            {
+                                "name": "interface",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "mac",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[mac]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>MAC address of interface</p>\n"
+                                    },
+                                    {
+                                        "name": "ip",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[ip]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>IP address of interface</p>\n"
+                                    },
+                                    {
+                                        "name": "type",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[type]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Interface type, i.e: Nic::BMC</p>\n"
+                                    },
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Interface name</p>\n"
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Fixnum",
+                                        "full_name": "interface[subnet_id]",
+                                        "expected_type": "numeric",
+                                        "metadata": null,
+                                        "description": "\n<p>Foreman subnet id of interface</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Fixnum",
+                                        "full_name": "interface[domain_id]",
+                                        "expected_type": "numeric",
+                                        "metadata": null,
+                                        "description": "\n<p>Foreman domain id of interface</p>\n"
+                                    },
+                                    {
+                                        "name": "username",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[username]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provider",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[provider]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Interface provider, i.e: IPMI</p>\n"
+                                    }
+                                ],
+                                "full_name": "interface",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": "\n<p>interface information</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/interfaces/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update host interface",
+                                "http_method": "PUT",
+                                "api_url": "/api/hosts/:host_id/interfaces/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id or name of host</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "interface",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "mac",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[mac]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>MAC address of interface</p>\n"
+                                    },
+                                    {
+                                        "name": "ip",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[ip]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>IP address of interface</p>\n"
+                                    },
+                                    {
+                                        "name": "type",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[type]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Interface type, i.e: Nic::BMC</p>\n"
+                                    },
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Interface name</p>\n"
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Fixnum",
+                                        "full_name": "interface[subnet_id]",
+                                        "expected_type": "numeric",
+                                        "metadata": null,
+                                        "description": "\n<p>Foreman subnet id of interface</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Fixnum",
+                                        "full_name": "interface[domain_id]",
+                                        "expected_type": "numeric",
+                                        "metadata": null,
+                                        "description": "\n<p>Foreman domain id of interface</p>\n"
+                                    },
+                                    {
+                                        "name": "username",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[username]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "password",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[password]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provider",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "interface[provider]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Interface provider, i.e: IPMI</p>\n"
+                                    }
+                                ],
+                                "full_name": "interface",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": "\n<p>interface information</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/interfaces/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a host interface",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hosts/:host_id/interfaces/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of interface</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/interfaces/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/interfaces",
+                "name": "Interfaces"
+            },
+            "os_default_templates": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List os default templates for operating system",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/os_default_templates"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/os_default_templates/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a os default template kind for operating system",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/os_default_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a number.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/os_default_templates/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a os default template for operating system",
+                                "http_method": "POST",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/os_default_templates"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "os_default_template",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "template_kind_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "os_default_template[template_kind_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "config_template_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "os_default_template[config_template_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "os_default_template",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/os_default_templates/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a os default template for operating system",
+                                "http_method": "PUT",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/os_default_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "os_default_template",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "template_kind_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "os_default_template[template_kind_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "config_template_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "os_default_template[config_template_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "os_default_template",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/os_default_templates/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a os default template for operating system",
+                                "http_method": "DELETE",
+                                "api_url": "/api/operatingsystems/:operatingsystem_id/os_default_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "operatingsystem_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "operatingsystem_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of operating system</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/os_default_templates/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/os_default_templates",
+                "name": "Os default templates"
+            },
+            "template_combinations": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List Template Combination",
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates/:config_template_id/template_combinations"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "config_template_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "config_template_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/template_combinations/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Add a Template Combination",
+                                "http_method": "POST",
+                                "api_url": "/api/config_templates/:config_template_id/template_combinations"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "config_template_id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "config_template_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "template_combination",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "environment_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "template_combination[environment_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>environment id</p>\n"
+                                    },
+                                    {
+                                        "name": "hostgroup_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "template_combination[hostgroup_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>hostgroup id</p>\n"
+                                    }
+                                ],
+                                "full_name": "template_combination",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/template_combinations/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show Template Combination",
+                                "http_method": "GET",
+                                "api_url": "/api/template_combinations/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/template_combinations/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a template",
+                                "http_method": "DELETE",
+                                "api_url": "/api/template_combinations/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/template_combinations/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/template_combinations",
+                "name": "Template combinations"
+            },
+            "config_templates": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List templates",
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_templates/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show template details",
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_templates/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a template",
+                                "http_method": "POST",
+                                "api_url": "/api/config_templates"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "config_template",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>template name</p>\n"
+                                    },
+                                    {
+                                        "name": "template",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[template]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "snippet",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "config_template[snippet]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "audit_comment",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[audit_comment]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "template_kind_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "config_template[template_kind_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not relevant for snippet</p>\n"
+                                    },
+                                    {
+                                        "name": "template_combinations_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[template_combinations_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of template combinations (hostgroup_id, environment_id)</p>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of operating systems ID to associate the template with</p>\n"
+                                    }
+                                ],
+                                "full_name": "config_template",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_templates/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a template",
+                                "http_method": "PUT",
+                                "api_url": "/api/config_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "config_template",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>template name</p>\n"
+                                    },
+                                    {
+                                        "name": "template",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[template]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "snippet",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "config_template[snippet]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "audit_comment",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "config_template[audit_comment]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "template_kind_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "config_template[template_kind_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not relevant for snippet</p>\n"
+                                    },
+                                    {
+                                        "name": "template_combinations_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[template_combinations_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of template combinations (hostgroup_id, environment_id)</p>\n"
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "config_template[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of operating systems ID to associate the template with</p>\n"
+                                    }
+                                ],
+                                "full_name": "config_template",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_templates/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "revision",
+                        "apis": [
+                            {
+                                "short_description": null,
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates/revision"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "version",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "version",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>template version</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_templates/revision",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a template",
+                                "http_method": "DELETE",
+                                "api_url": "/api/config_templates/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_templates/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "build_pxe_default",
+                        "apis": [
+                            {
+                                "short_description": "Change the default PXE menu on all configured TFTP servers",
+                                "http_method": "GET",
+                                "api_url": "/api/config_templates/build_pxe_default"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/config_templates/build_pxe_default",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/config_templates",
+                "name": "Config templates"
+            },
+            "usergroups": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all usergroups.",
+                                "http_method": "GET",
+                                "api_url": "/api/usergroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            },
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/usergroups/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a usergroup.",
+                                "http_method": "GET",
+                                "api_url": "/api/usergroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/usergroups/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a usergroup.",
+                                "http_method": "POST",
+                                "api_url": "/api/usergroups"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "usergroup",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "usergroup[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "usergroup",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/usergroups/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a usergroup.",
+                                "http_method": "PUT",
+                                "api_url": "/api/usergroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "usergroup",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "usergroup[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "usergroup",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/usergroups/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a usergroup.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/usergroups/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/usergroups/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/usergroups",
+                "name": "Usergroups"
+            },
+            "architectures": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all architectures.",
+                                "http_method": "GET",
+                                "api_url": "/api/architectures"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/architectures/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an architecture.",
+                                "http_method": "GET",
+                                "api_url": "/api/architectures/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/architectures/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an architecture.",
+                                "http_method": "POST",
+                                "api_url": "/api/architectures"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "architecture",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "architecture[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "architecture[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Operatingsystem ID's</p>\n"
+                                    }
+                                ],
+                                "full_name": "architecture",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/architectures/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an architecture.",
+                                "http_method": "PUT",
+                                "api_url": "/api/architectures/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "architecture",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "architecture[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "architecture[operatingsystem_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Operatingsystem ID's</p>\n"
+                                    }
+                                ],
+                                "full_name": "architecture",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/architectures/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an architecture.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/architectures/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/architectures/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/architectures",
+                "name": "Architectures"
+            },
+            "realms": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List of realms",
+                                "http_method": "GET",
+                                "api_url": "/api/realms"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/realms/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a realm.",
+                                "http_method": "GET",
+                                "api_url": "/api/realms/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>May be numerical id or realm name</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/realms/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a realm.",
+                                "http_method": "POST",
+                                "api_url": "/api/realms"
+                            }
+                        ],
+                        "full_description": "\n<p>The <strong>name</strong> field is used for the name of the realm.</p>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "realm",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "realm[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The realm name, e.g. EXAMPLE.COM</p>\n"
+                                    },
+                                    {
+                                        "name": "realm_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "realm[realm_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Proxy to use for this realm</p>\n"
+                                    },
+                                    {
+                                        "name": "realm_type",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "realm[realm_type]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Realm type, e.g. FreeIPA or Active Directory</p>\n"
+                                    }
+                                ],
+                                "full_name": "realm",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/realms/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a realm.",
+                                "http_method": "PUT",
+                                "api_url": "/api/realms/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "realm",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "realm[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The realm name, e.g. EXAMPLE.COM</p>\n"
+                                    },
+                                    {
+                                        "name": "realm_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "realm[realm_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Proxy to use for this realm</p>\n"
+                                    },
+                                    {
+                                        "name": "realm_type",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "realm[realm_type]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Realm type, e.g. FreeIPA or Active Directory</p>\n"
+                                    }
+                                ],
+                                "full_name": "realm",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/realms/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a realm.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/realms/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/realms/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/realms",
+                "name": "Realms"
+            },
+            "puppetclasses": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all puppetclasses.",
+                                "http_method": "GET",
+                                "api_url": "/api/puppetclasses"
+                            },
+                            {
+                                "short_description": "List all puppetclasses for host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/puppetclasses"
+                            },
+                            {
+                                "short_description": "List all puppetclasses for hostgroup",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups/:hostgroup_id/puppetclasses"
+                            },
+                            {
+                                "short_description": "List all puppetclasses for environment",
+                                "http_method": "GET",
+                                "api_url": "/api/environments/:environment_id/puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of nested host</p>\n"
+                            },
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of nested hostgroup</p>\n"
+                            },
+                            {
+                                "name": "environment_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "environment_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of nested environment</p>\n"
+                            },
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/puppetclasses/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a puppetclass",
+                                "http_method": "GET",
+                                "api_url": "/api/puppetclasses/:id"
+                            },
+                            {
+                                "short_description": "Show a puppetclass for host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/puppetclasses/:id"
+                            },
+                            {
+                                "short_description": "Show a puppetclass for hostgroup",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups/:hostgroup_id/puppetclasses/:id"
+                            },
+                            {
+                                "short_description": "Show a puppetclass for environment",
+                                "http_method": "GET",
+                                "api_url": "/api/environments/:environment_id/puppetclasses/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of nested host</p>\n"
+                            },
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of nested hostgroup</p>\n"
+                            },
+                            {
+                                "name": "environment_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "environment_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of nested environment</p>\n"
+                            },
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>id of puppetclass</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/puppetclasses/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a puppetclass.",
+                                "http_method": "POST",
+                                "api_url": "/api/puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "puppetclass",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "puppetclass[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "puppetclass",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/puppetclasses/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a puppetclass.",
+                                "http_method": "PUT",
+                                "api_url": "/api/puppetclasses/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "puppetclass",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "puppetclass[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "puppetclass",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/puppetclasses/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a puppetclass.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/puppetclasses/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/puppetclasses/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/puppetclasses",
+                "name": "Puppetclasses"
+            },
+            "permissions": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all permissions.",
+                                "http_method": "GET",
+                                "api_url": "/api/permissions"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            },
+                            {
+                                "name": "resource_type",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "resource_type",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "name",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "name",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/permissions/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a permission.",
+                                "http_method": "GET",
+                                "api_url": "/api/permissions/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/permissions/show",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/permissions",
+                "name": "Permissions"
+            },
+            "organizations": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all organizations",
+                                "http_method": "GET",
+                                "api_url": "/api/organizations"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/organizations/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an organization",
+                                "http_method": "GET",
+                                "api_url": "/api/organizations/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/organizations/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an organization",
+                                "http_method": "POST",
+                                "api_url": "/api/organizations"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "organization",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "organization[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "organization",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/organizations/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an organization",
+                                "http_method": "PUT",
+                                "api_url": "/api/organizations/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "organization",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "organization[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "organization",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/organizations/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an organization",
+                                "http_method": "DELETE",
+                                "api_url": "/api/organizations/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/organizations/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/organizations",
+                "name": "Organizations"
+            },
+            "smart_variables": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all smart variables",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_variables"
+                            },
+                            {
+                                "short_description": "List of smart variables for a specific host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/smart_variables"
+                            },
+                            {
+                                "short_description": "List of smart variables for a specific hostgroup",
+                                "http_method": "GET",
+                                "api_url": "/api/hostgroups/:hostgroup_id/smart_variables"
+                            },
+                            {
+                                "short_description": "List of smart variables for a specific puppetclass",
+                                "http_method": "GET",
+                                "api_url": "/api/puppetclasses/:puppetclass_id/smart_variables"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "host_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "hostgroup_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "hostgroup_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "puppetclass_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "puppetclass_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_variables/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a smart variable.",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_variables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_variables/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a smart variable.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_variables"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "smart_variable",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "variable",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[variable]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppetclass_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "smart_variable[puppetclass_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "default_value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[default_value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "override_value_order",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[override_value_order]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "validator_type",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[validator_type]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "validator_rule",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[validator_rule]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "variable_type",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[variable_type]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "smart_variable",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_variables/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a smart variable.",
+                                "http_method": "PUT",
+                                "api_url": "/api/smart_variables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_variable",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "variable",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[variable]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppetclass_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "smart_variable[puppetclass_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "default_value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[default_value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "override_value_order",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[override_value_order]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "validator_type",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[validator_type]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "validator_rule",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[validator_rule]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "variable_type",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_variable[variable_type]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "smart_variable",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_variables/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a smart variable.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/smart_variables/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_variables/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/smart_variables",
+                "name": "Smart variables"
+            },
+            "roles": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all roles.",
+                                "http_method": "GET",
+                                "api_url": "/api/roles"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/roles/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an role.",
+                                "http_method": "GET",
+                                "api_url": "/api/roles/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/roles/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an role.",
+                                "http_method": "POST",
+                                "api_url": "/api/roles"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "role",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "role[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "role",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/roles/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an role.",
+                                "http_method": "PUT",
+                                "api_url": "/api/roles/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "role",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "role[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "role",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/roles/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an role.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/roles/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/roles/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/roles",
+                "name": "Roles"
+            },
+            "settings": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all settings.",
+                                "http_method": "GET",
+                                "api_url": "/api/settings"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/settings/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an setting.",
+                                "http_method": "GET",
+                                "api_url": "/api/settings/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/settings/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a setting.",
+                                "http_method": "PUT",
+                                "api_url": "/api/settings/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "setting",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "value",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "setting[value]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "setting",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/settings/update",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/settings",
+                "name": "Settings"
+            },
+            "smart_proxies": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "import_puppetclasses",
+                        "apis": [
+                            {
+                                "short_description": "Import puppet classes from puppet proxy.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses"
+                            },
+                            {
+                                "short_description": "Import puppet classes from puppet proxy for particular environment.",
+                                "http_method": "POST",
+                                "api_url": "/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_proxy_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "smart_proxy_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "environment_id",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "environment_id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "dryrun",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be 'true' or 'false'",
+                                "full_name": "dryrun",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "except",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "except",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Optional comma-deliminated string containing either 'new,updated,obsolete'\nused to limit the import_puppetclasses actions</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_proxies/import_puppetclasses",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all smart_proxies.",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_proxies"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_proxies/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a smart proxy.",
+                                "http_method": "GET",
+                                "api_url": "/api/smart_proxies/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_proxies/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a smart proxy.",
+                                "http_method": "POST",
+                                "api_url": "/api/smart_proxies"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "smart_proxy",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "url",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[url]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "smart_proxy",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_proxies/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a smart proxy.",
+                                "http_method": "PUT",
+                                "api_url": "/api/smart_proxies/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "smart_proxy",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "url",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "smart_proxy[url]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "smart_proxy",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_proxies/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a smart_proxy.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/smart_proxies/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_proxies/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "refresh",
+                        "apis": [
+                            {
+                                "short_description": "Refresh smart proxy features",
+                                "http_method": "PUT",
+                                "api_url": "/api/smart_proxies/:id/refresh"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/smart_proxies/refresh",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/smart_proxies",
+                "name": "Smart proxies"
+            },
+            "reports": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all reports.",
+                                "http_method": "GET",
+                                "api_url": "/api/reports"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/reports/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a report.",
+                                "http_method": "GET",
+                                "api_url": "/api/reports/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/reports/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a report.",
+                                "http_method": "POST",
+                                "api_url": "/api/reports"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "report",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "host",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "report[host]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Hostname or certname</p>\n"
+                                    },
+                                    {
+                                        "name": "reported_at",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "report[reported_at]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>UTC time of report</p>\n"
+                                    },
+                                    {
+                                        "name": "status",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be Hash",
+                                        "full_name": "report[status]",
+                                        "expected_type": "hash",
+                                        "metadata": null,
+                                        "description": "\n<p>Hash of status type totals</p>\n"
+                                    },
+                                    {
+                                        "name": "metrics",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be Hash",
+                                        "full_name": "report[metrics]",
+                                        "expected_type": "hash",
+                                        "metadata": null,
+                                        "description": "\n<p>Hash of report metrics, can be just {}</p>\n"
+                                    },
+                                    {
+                                        "name": "logs",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "report[logs]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Optional array of log hashes</p>\n"
+                                    }
+                                ],
+                                "full_name": "report",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/reports/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a report.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/reports/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/reports/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "last",
+                        "apis": [
+                            {
+                                "short_description": "Show the last report for a given host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:host_id/reports/last"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/reports/last",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/reports",
+                "name": "Reports"
+            },
+            "hosts": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all hosts.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hosts/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a host.",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hosts/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a host.",
+                                "http_method": "POST",
+                                "api_url": "/api/hosts"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "host",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[environment_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ip",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[ip]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not required if using a subnet with dhcp proxy</p>\n"
+                                    },
+                                    {
+                                        "name": "mac",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[mac]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not required if its a virtual machine</p>\n"
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[domain_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "realm_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[realm_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_class_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[puppet_class_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[medium_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[ptable_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "sp_subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[sp_subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "model_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[model_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hostgroup_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[hostgroup_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "owner_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[owner_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "image_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[image_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host_parameters_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[host_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "build",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[build]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "enabled",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[enabled]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provision_method",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[provision_method]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "managed",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[managed]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "progress_report_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[progress_report_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>UUID to track orchestration tasks status, GET\n/api/orchestration/:UUID/tasks</p>\n"
+                                    },
+                                    {
+                                        "name": "capabilities",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[capabilities]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a Hash",
+                                        "params": [],
+                                        "full_name": "host[compute_attributes]",
+                                        "expected_type": "hash",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "host",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hosts/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a host.",
+                                "http_method": "PUT",
+                                "api_url": "/api/hosts/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "host",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "host[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "environment_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[environment_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ip",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[ip]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not required if using a subnet with dhcp proxy</p>\n"
+                                    },
+                                    {
+                                        "name": "mac",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[mac]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>not required if its a virtual machine</p>\n"
+                                    },
+                                    {
+                                        "name": "architecture_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[architecture_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "domain_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[domain_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "realm_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[realm_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_class_ids",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[puppet_class_ids]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "operatingsystem_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[operatingsystem_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "medium_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[medium_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "ptable_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[ptable_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_resource_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[compute_resource_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "sp_subnet_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[sp_subnet_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "model_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[model_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "hostgroup_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[hostgroup_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "owner_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[owner_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "puppet_ca_proxy_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[puppet_ca_proxy_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "image_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "host[image_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "host_parameters_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "host[host_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "build",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[build]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "enabled",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[enabled]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "provision_method",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[provision_method]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "managed",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be 'true' or 'false'",
+                                        "full_name": "host[managed]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "progress_report_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[progress_report_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>UUID to track orchestration tasks status, GET\n/api/orchestration/:UUID/tasks</p>\n"
+                                    },
+                                    {
+                                        "name": "capabilities",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "host[capabilities]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "compute_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a Hash",
+                                        "params": [],
+                                        "full_name": "host[compute_attributes]",
+                                        "expected_type": "hash",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "host",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hosts/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an host.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/hosts/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hosts/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "status",
+                        "apis": [
+                            {
+                                "short_description": "Get status of host",
+                                "http_method": "GET",
+                                "api_url": "/api/hosts/:id/status"
+                            }
+                        ],
+                        "full_description": "\n<p>Return value may either be one of the following:</p>\n<ul><li>\n<p>missing</p>\n</li><li>\n<p>failed</p>\n</li><li>\n<p>pending</p>\n</li><li>\n<p>changed</p>\n</li><li>\n<p>unchanged</p>\n</li><li>\n<p>unreported</p>\n</li></ul>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hosts/status",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "puppetrun",
+                        "apis": [
+                            {
+                                "short_description": "Force a puppet run on the agent.",
+                                "http_method": "PUT",
+                                "api_url": "/api/hosts/:id/puppetrun"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hosts/puppetrun",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "power",
+                        "apis": [
+                            {
+                                "short_description": "Run power operation on host.",
+                                "http_method": "PUT",
+                                "api_url": "/api/hosts/:id/power"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "power_action",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "power_action",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>power action, valid actions are ('on', 'start')', ('off', 'stop'), ('soft',\n'reboot'), ('cycle', 'reset'), ('state', 'status')</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hosts/power",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "boot",
+                        "apis": [
+                            {
+                                "short_description": "Boot host from specified device.",
+                                "http_method": "PUT",
+                                "api_url": "/api/hosts/:id/boot"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "device",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "device",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>boot device, valid devices are disk, cdrom, pxe, bios</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hosts/boot",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "facts",
+                        "apis": [
+                            {
+                                "short_description": "Upload facts for a host, creating the host if required.",
+                                "http_method": "POST",
+                                "api_url": "/api/hosts/facts"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "name",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "name",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>hostname of the host</p>\n"
+                            },
+                            {
+                                "name": "facts",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be Hash",
+                                "full_name": "facts",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": "\n<p>hash containing the facts for the host</p>\n"
+                            },
+                            {
+                                "name": "certname",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "certname",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>optional: certname of the host</p>\n"
+                            },
+                            {
+                                "name": "type",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "type",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>optional: the STI type of host to create</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/hosts/facts",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/hosts",
+                "name": "Hosts"
+            },
+            "dashboard": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": null,
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "Get Dashboard results",
+                                "http_method": "GET",
+                                "api_url": "/api/dashboard"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/dashboard/index",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/dashboard",
+                "name": "Dashboard"
+            },
+            "domains": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": "\n<p>Foreman considers a domain and a DNS zone as the same thing. That is, if\nyou are planning to manage a site where all the machines are or the form\n<em>hostname</em>.<strong>somewhere.com</strong> then the domain is\n<strong>somewhere.com</strong>. This allows Foreman to associate a puppet\nvariable with a domain/site and automatically append this variable to all\nexternal node requests made by machines at that site.</p>\n",
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List of domains",
+                                "http_method": "GET",
+                                "api_url": "/api/domains"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>Sort results</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/domains/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show a domain.",
+                                "http_method": "GET",
+                                "api_url": "/api/domains/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>May be numerical id or domain name</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/domains/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create a domain.",
+                                "http_method": "POST",
+                                "api_url": "/api/domains"
+                            }
+                        ],
+                        "full_description": "\n<p>The <strong>fullname</strong> field is used for human readability in\nreports and other pages that refer to domains, and also available as an\nexternal node parameter</p>\n",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "domain",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The full DNS Domain name</p>\n"
+                                    },
+                                    {
+                                        "name": "fullname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[fullname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Full name describing the domain</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "domain[dns_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DNS Proxy to use within this domain</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_parameters_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "domain[domain_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of parameters (name, value)</p>\n"
+                                    }
+                                ],
+                                "full_name": "domain",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/domains/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update a domain.",
+                                "http_method": "PUT",
+                                "api_url": "/api/domains/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "domain",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>The full DNS Domain name</p>\n"
+                                    },
+                                    {
+                                        "name": "fullname",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "domain[fullname]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>Full name describing the domain</p>\n"
+                                    },
+                                    {
+                                        "name": "dns_id",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be a number.",
+                                        "full_name": "domain[dns_id]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": "\n<p>DNS Proxy to use within this domain</p>\n"
+                                    },
+                                    {
+                                        "name": "domain_parameters_attributes",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be Array",
+                                        "full_name": "domain[domain_parameters_attributes]",
+                                        "expected_type": "array",
+                                        "metadata": null,
+                                        "description": "\n<p>Array of parameters (name, value)</p>\n"
+                                    }
+                                ],
+                                "full_name": "domain",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/domains/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete a domain.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/domains/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, space, underscore(_), hypen(-) with no leading or trailing space.",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/domains/destroy",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/domains",
+                "name": "Domains"
+            },
+            "operatingsystems": {
+                "api_url": "/api",
+                "metadata": null,
+                "full_description": "",
+                "version": "v2",
+                "methods": [
+                    {
+                        "errors": [],
+                        "name": "index",
+                        "apis": [
+                            {
+                                "short_description": "List all operating systems.",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "search",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "search",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>filter results</p>\n"
+                            },
+                            {
+                                "name": "order",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "order",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>for example, name ASC, or name DESC</p>\n"
+                            },
+                            {
+                                "name": "page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>paginate results</p>\n"
+                            },
+                            {
+                                "name": "per_page",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "per_page",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": "\n<p>number of entries per request</p>\n"
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/operatingsystems/index",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "show",
+                        "apis": [
+                            {
+                                "short_description": "Show an OS.",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/operatingsystems/show",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "create",
+                        "apis": [
+                            {
+                                "short_description": "Create an OS.",
+                                "http_method": "POST",
+                                "api_url": "/api/operatingsystems"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "operatingsystem",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must match regular expression /\\A(\\S+)\\Z/.",
+                                        "full_name": "operatingsystem[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "major",
+                                        "show": true,
+                                        "required": true,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[major]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "minor",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[minor]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "release_name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[release_name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "operatingsystem",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/operatingsystems/create",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "update",
+                        "apis": [
+                            {
+                                "short_description": "Update an OS.",
+                                "http_method": "PUT",
+                                "api_url": "/api/operatingsystems/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "operatingsystem",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": true,
+                                "validator": "Must be a Hash",
+                                "params": [
+                                    {
+                                        "name": "name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must match regular expression /\\A(\\S+)\\Z/.",
+                                        "full_name": "operatingsystem[name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "major",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": false,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[major]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "minor",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[minor]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "description",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[description]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "family",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[family]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    },
+                                    {
+                                        "name": "release_name",
+                                        "show": true,
+                                        "required": false,
+                                        "allow_nil": true,
+                                        "validator": "Must be String",
+                                        "full_name": "operatingsystem[release_name]",
+                                        "expected_type": "string",
+                                        "metadata": null,
+                                        "description": ""
+                                    }
+                                ],
+                                "full_name": "operatingsystem",
+                                "expected_type": "hash",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/operatingsystems/update",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "destroy",
+                        "apis": [
+                            {
+                                "short_description": "Delete an OS.",
+                                "http_method": "DELETE",
+                                "api_url": "/api/operatingsystems/:id"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/operatingsystems/destroy",
+                        "metadata": null
+                    },
+                    {
+                        "errors": [],
+                        "name": "bootfiles",
+                        "apis": [
+                            {
+                                "short_description": "List boot files an OS.",
+                                "http_method": "GET",
+                                "api_url": "/api/operatingsystems/:id/bootfiles"
+                            }
+                        ],
+                        "full_description": "",
+                        "see": [],
+                        "params": [
+                            {
+                                "name": "id",
+                                "show": true,
+                                "required": true,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "id",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "medium",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "medium",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            },
+                            {
+                                "name": "architecture",
+                                "show": true,
+                                "required": false,
+                                "allow_nil": false,
+                                "validator": "Must be String",
+                                "full_name": "architecture",
+                                "expected_type": "string",
+                                "metadata": null,
+                                "description": ""
+                            }
+                        ],
+                        "examples": [],
+                        "formats": null,
+                        "doc_url": "/apidoc/v2/operatingsystems/bootfiles",
+                        "metadata": null
+                    }
+                ],
+                "formats": null,
+                "short_description": null,
+                "doc_url": "/apidoc/v2/operatingsystems",
+                "name": "Operating systems"
+            }
+        },
+        "api_url": "/api"
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_desc = open('README.rst').read()
 
 setup(
     name="python-foreman",
-    version="0.2",
+    version="0.2.1",
     description="Simple low-level client library to access the Foreman API",
     long_description=long_desc,
     author="David Caro",
@@ -16,4 +16,7 @@ setup(
     install_requires=[
         'requests>=0.14',
     ],
+    package_data={
+        'foreman': ['definitions/*.json'],
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+minversion = 1.6
+envlist = pep8, py27
+
+[testenv:pep8]
+deps = flake8
+commands = flake8
+
+[testenv:pyflakes]
+deps = pyflakes
+commands = pyflakes jenkins_jobs tests setup.py
+
+[testenv:venv]
+commands = {posargs}
+
+[flake8]
+ignore = E125,H
+show-source = True
+exclude = .venv,.tox,dist,doc,build,*.egg


### PR DESCRIPTION
- Added 1.4.2 and 1.5.0 cache files (compatible with for 1.4.\* 1.5.\* foreman
  instances)
- Added missing create_\* methods
- Improved the cache logic
- Added json cache files to the package
- Api v1 is the default to be backwards compatible, adding a warning to
  let people adjust, next version will have the version 2 as default
