### PR TITLE
fix getting version from home page with bad HTTP headers

### DIFF
--- a/foreman/client.py
+++ b/foreman/client.py
@@ -357,7 +357,7 @@ class Foreman(object):
         main page and extract the version from the footer.
         """
         params = dict(self._req_params)
-        home_page = self.session.get(self.url, **params)
+        home_page = requests.get(self.url, **params)
         match = re.search(r'Version\s+(?P<version>\S+)', home_page.text)
         if match:
             return match.groupdict()['version']


### PR DESCRIPTION
This small change fixes get_foreman_version method by not getting home page with session, which has HTTP headers for accepting just JSON, but instead with requests.get method. This fixed our issue with Foreman class initialization.