### PR TITLE
Use do_get() for get_foreman_version() and _get_remote_defs() as well

### DIFF
--- a/foreman/client.py
+++ b/foreman/client.py
@@ -523,7 +523,7 @@ class Foreman(object):
             will try to get them from the remote Foreman instance (it needs
             you to have disabled use_cache in the apipie configuration in your
             foreman instance)
-        :param sctrict_cache: If True, will not use a similar version
+        :param strict_cache: If True, will not use a similar version
             definitions file
         :param timeout: Timeout in seconds for each http request (default 60)
             If None or 0, then no timeout.
@@ -684,7 +684,7 @@ class Foreman(object):
 
     def _get_remote_defs(self):
         """
-        Retrieves the json definitions from remote forem
+        Retrieves the json definitions from remote foreman instance.
         """
         res = self.do_get(
             'apidoc/v%s.json' % self.api_version,
@@ -810,7 +810,7 @@ class Foreman(object):
                 resource_data,
             )
             if not resource_data['_own_methods']:
-                logging.debug('Skiping empty resource %s' % resource_name)
+                logging.debug('Skipping empty resource %s' % resource_name)
                 continue
             instance = new_resource(self)
             setattr(self, resource_name, instance)

--- a/foreman/client.py
+++ b/foreman/client.py
@@ -613,14 +613,13 @@ class Foreman(object):
         the version first to know its path, so instead of that we get the
         main page and extract the version from the footer.
         """
-        params = dict(self._req_params)
-        home_page = self.session.get(self.url, **params)
+        home_page = self.do_get('/', None)
         match = re.search(r'Version\s+(?P<version>\S+)', home_page.text)
         if match:
             return match.groupdict()['version']
         else:
             # on newer versions the version can be taken from the status page
-            res = self.session.get(self.url + '/api/status', **params)
+            res = self.do_get('/api/status', None)
             if res.status_code < 200 or res.status_code >= 300:
                 raise ForemanException(
                     res,
@@ -687,9 +686,9 @@ class Foreman(object):
         """
         Retrieves the json definitions from remote forem
         """
-        res = self.session.get(
-            '%s/%s' % (self.url, 'apidoc/v%s.json' % self.api_version),
-            **self._req_params
+        res = self.do_get(
+            'apidoc/v%s.json' % self.api_version,
+            None
         )
 
         if res.ok:


### PR DESCRIPTION
The two methods used to call self.session.get() directly, thereby ignoring
configured timeouts.