### PR TITLE
Suppress API resource redefinition warnings for repeated definitions

### DIFF
--- a/foreman/client.py
+++ b/foreman/client.py
@@ -334,6 +334,11 @@ def parse_resource_definition(resource_name, resource_dct):
                 functions = foreign_methods.setdefault(api.resource, {})
                 if api.name in functions:
                     old_api = functions.get(api.name).defs
+
+                    # ignore repeated but identical definitions
+                    if api.url == old_api.url:
+                        continue
+
                     logging.warning(
                         "There is a conflict trying to redefine a method "
                         "for a foreign resource (%s): \n"
@@ -358,6 +363,11 @@ def parse_resource_definition(resource_name, resource_dct):
                 # it's an own method, resource and url match
                 if api.name in new_dict['_own_methods']:
                     old_api = new_dict.get(api.name).defs
+
+                    # ignore repeated but identical definitions
+                    if api.url == old_api.url:
+                        continue
+
                     logging.warning(
                         "There is a conflict trying to redefine method "
                         "(%s): \n"


### PR DESCRIPTION
The JSON definitions retrieved from a Foreman instance could contain repeated
but identical method definitions (this was eg. the case for Foreman 1.7.5.).
No need to log a warning here since this behavior doesn't have any actual
negative effect.