### PR TITLE
Show duplicated definitions only in debug log level

### DIFF
--- a/foreman/client.py
+++ b/foreman/client.py
@@ -745,7 +745,7 @@ class Foreman(object):
                 try:
                     os.makedirs(defs_path)
                 except:
-                    logging.debug('Unable to create cache dir %s', defs_path)
+                    logger.debug('Unable to create cache dir %s', defs_path)
                     return
             cache_fn = '%s/%s-v%s.json' % (
                 defs_path, self.version,
@@ -754,7 +754,7 @@ class Foreman(object):
             try:
                 with open(cache_fn, 'w') as cache_fd:
                     cache_fd.write(json.dumps(data, indent=4, default=str))
-                    logging.debug('Wrote cache file %s', cache_fn)
+                    logger.debug('Wrote cache file %s', cache_fn)
             except:
                 logger.debug('Unable to write cache file %s', cache_fn)
         else:

--- a/foreman/client.py
+++ b/foreman/client.py
@@ -334,6 +334,11 @@ def parse_resource_definition(resource_name, resource_dct):
                 functions = foreign_methods.setdefault(api.resource, {})
                 if api.name in functions:
                     old_api = functions.get(api.name).defs
+
+                    # ignore repeated but identical definitions
+                    if api.url == old_api.url:
+                        continue
+
                     logging.warning(
                         "There is a conflict trying to redefine a method "
                         "for a foreign resource (%s): \n"
@@ -358,6 +363,11 @@ def parse_resource_definition(resource_name, resource_dct):
                 # it's an own method, resource and url match
                 if api.name in new_dict['_own_methods']:
                     old_api = new_dict.get(api.name).defs
+
+                    # ignore repeated but identical definitions
+                    if api.url == old_api.url:
+                        continue
+
                     logging.warning(
                         "There is a conflict trying to redefine method "
                         "(%s): \n"


### PR DESCRIPTION
Based on #56, but adding the two missed logging calls.