### PR TITLE
Fix JSONDecodeError reference

### DIFF
--- a/foreman/client.py
+++ b/foreman/client.py
@@ -881,7 +881,7 @@ class Foreman(object):
             )
         try:
             return OLD_REQ and res.json or res.json()
-        except requests.JSONDecodeError:
+        except ValueError:
             return res.text
 
     def do_get(self, url, kwargs):


### PR DESCRIPTION
The "requests" module does not know about JSONDecodeError because it actually
comes from the underlying simplejson module. Reuse requests' internal
reference so we notice if requests should ever change from simplejson to
a different module.