### PR TITLE
tests: simplify and adapt to latest pytest

### DIFF
--- a/foreman/client.py
+++ b/foreman/client.py
@@ -490,6 +490,7 @@ class MetaForeman(type):
             resource_data[mname] = tuple(method_dict.values())[0]
             resource_data['_own_methods'].add(mname)
 
+        logger.info(resource_data)
         plugins_cls = ResourceMeta.__new__(
             ResourceMeta,
             'plugins',

--- a/tests/test_defs.py
+++ b/tests/test_defs.py
@@ -1,53 +1,81 @@
+#!/usr/bin/env python
+# encoding: utf-8
+from __future__ import absolute_import, division, print_function
+
 import os
 import six
-import logging
+
+import pytest
 from foreman.client import Foreman, Resource, requests
+
 from .mocks import SessionMock
 
 
-class DefsGen(object):
+URL = 'foreman.example.com'
 
-    url = 'foreman.example.com'
 
-    def __init__(self, foreman_version, api_version):
-        self.frmn_ver = foreman_version
-        self.api_ver = api_version
-        self.logger = logging.getLogger(
-            "Foreman-%s-%s" % (self.frmn_ver, self.api_ver)
-        )
-
-    def check_api(self):
-        f = self.generate_api()
-        for value in six.itervalues(f.__dict__):
-            if not isinstance(value, Resource):
-                continue
-            self.check_resource(value)
-
-    def generate_api(self):
-        requests.Session = SessionMock(self.url, self.frmn_ver)
-        self.logger.info("Generate api")
-        return Foreman(
-            self.url,
-            version=self.frmn_ver,
-            api_version=self.api_ver,
-        )
-
-    def check_resource(self, resource):
-        self.logger.info("Checking resource: %s", resource)
-        # assert not resource._unbound_methods
-
-    def __repr__(self):
-        return "DefsGen(frmn_ver=%s, api_ver=%s)" % (
-            self.frmn_ver,
-            self.api_ver,
+class HasConflictingMethods(Exception):
+    def __init__(self, resource, conflicting_methods):
+        super(HasConflictingMethods, self).__init__(
+            '%s has conflicting methods:' +
+            '\n    '.join(str(method) for method in conflicting_methods)
         )
 
 
-def test_apis():
+def check_api(url, foreman_version, api_version):
+    cli = generate_api(url, foreman_version, api_version)
+    for value in six.itervalues(cli.__dict__):
+        if not isinstance(value, Resource):
+            continue
+
+        check_resource(resource=value)
+
+
+def generate_api(url, foreman_version, api_version):
+    requests.Session = SessionMock(url, foreman_version)
+    print("Generating api")
+    return Foreman(
+        url,
+        version=foreman_version,
+        api_version=api_version,
+    )
+
+
+def check_resource(resource):
+    print("Checking resource: %s" % resource)
+    conflicting_methods = getattr(resource, '_conflicting_methods', [])
+    if getattr(resource, '_conflicting_methods', []):
+        raise HasConflictingMethods(
+            resource,
+            conflicting_methods,
+        )
+
+    assert resource._own_methods
+
+
+def api_versions():
+    api_versions = []
     for json_file in os.listdir("foreman/definitions"):
         if json_file.endswith('.json'):
             version = json_file.strip('.json').split('-')
             if len(version) != 2:
                 continue
-            test = DefsGen(version[0], version[1].strip('v'))
-            yield test.check_api,
+            api_versions.append(version)
+
+    return api_versions
+
+
+@pytest.mark.parametrize(
+    'api_version',
+    api_versions(),
+    ids=[':'.join(ver) for ver in api_versions()],
+)
+def test_apis(api_version, capsys):
+    try:
+        check_api(
+            url=URL,
+            foreman_version=api_version[0],
+            api_version=api_version[1].strip('v'),
+        )
+    except HasConflictingMethods as error:
+        print('Got conflicting methods: %s' % error)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = pep8, py27, py35
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
-commands = py.test -s {toxinidir}/tests
+commands = py.test -v {toxinidir}/tests
 
 [testenv:pep8]
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
* The tests with yield are going to be deprecated, removed the extra
  class and refactored into functions.

Signed-off-by: David Caro <david@dcaro.es>