### PR TITLE
SSL 'verify' should be stored in 'self._req_params'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: python
-python:
-  - '2.7'
-  - '3.5'
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.6
+      env: TOXENV=py36
+    - env: TOXENV=pep8
 install:
   - pip install -r test-requirements.txt
 script:
-  - tox
+  - tox -e "$TOXENV"
 deploy:
   provider: pypi
   user: dcaro

--- a/foreman/client.py
+++ b/foreman/client.py
@@ -603,6 +603,7 @@ class Foreman(object):
         self.api_version = api_version
         self.session = requests.Session()
         self.session.verify = verify
+        self._req_params['verify'] = verify
         self.cache_dir = cache_dir or \
             os.path.join(os.path.expanduser('~'), '.python-foreman')
         if auth is not None:
@@ -656,12 +657,10 @@ class Foreman(object):
         the version first to know its path, so instead of that we get the
         main page and extract the version from the footer.
         """
-        params = dict(self._req_params)
         home_page = requests.get(
             self.url,
-            verify=self.session.verify,
             timeout=self.get_timeout('GET'),
-            **params
+            **self._req_params
         )
 
         match = re.search(
@@ -675,7 +674,7 @@ class Foreman(object):
             res = self.session.get(
                 self.url + '/api/status',
                 timeout=self.get_timeout('GET'),
-                **params
+                **self._req_params
             )
             if res.status_code < 200 or res.status_code >= 300:
                 raise ForemanException(

--- a/foreman/client.py
+++ b/foreman/client.py
@@ -760,7 +760,7 @@ class Foreman(object):
             if not os.path.exists(defs_path):
                 try:
                     os.makedirs(defs_path)
-                except:
+                except Exception:
                     logger.debug('Unable to create cache dir %s', defs_path)
                     return data
             cache_fn = '%s/%s-v%s.json' % (
@@ -771,7 +771,7 @@ class Foreman(object):
                 with open(cache_fn, 'w') as cache_fd:
                     cache_fd.write(json.dumps(data, indent=4, default=str))
                     logger.debug('Wrote cache file %s', cache_fn)
-            except:
+            except Exception:
                 logger.debug('Unable to write cache file %s', cache_fn)
         else:
             if res.status_code == 404:

--- a/scripts/version_manager.py
+++ b/scripts/version_manager.py
@@ -60,7 +60,7 @@ MAJOR_INVENIO = re.compile(r'\n\* INCOMPATIBLE')
 def get_repo_object(repo, object_name):
     try:
         object_name = object_name.encode()
-    except:
+    except Exception:
         pass
 
     return repo.get_object(object_name)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = pep8, py27, py35
+envlist = pep8, py27, py36
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
The usage of `self._req_params` was inconsistent. I made SSL `verify` global, which is what I believe was intended in commit de54bfd5d63e7a52a02113de35de59b8be117366.

Without this change, the function `_get_remote_defs()` is not able to make an **in**secure connection, even if you had set `verify=False`.

Instead of adding `verify=self.session.verify,` to `_get_remote_defs()` we just add `verify`s value to the dictionary.
