### PR TITLE
Avoid using Python 3.7 async reserved keyword

### DIFF
--- a/foreman/client.py
+++ b/foreman/client.py
@@ -241,6 +241,8 @@ class MethodAPIDescription(object):
             # this switch (and undo it inside the function we generate)
             if param['name'] == 'except':
                 local_name = 'except_'
+            if param['name'] == 'async':
+                local_name = 'async_'
             original_names[local_name] = param['name']
             keywords.append(local_name)
             if param['required']:


### PR DESCRIPTION
Title says it all.. In Python 3.7 there is Syntax Error, due to async being a reserved keyword now.